### PR TITLE
Add debugging tools to racetrack images

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.9-slim-bullseye
 
 WORKDIR /src/dashboard
 
-RUN apt-get update -y && apt-get install -y postgresql-client \
-  curl dnsutils vim
+RUN apt-get update -y && apt-get install -y \
+  postgresql-client curl dnsutils vim &&\
+  rm -rf /var/lib/apt/lists/*
 # apt cache is cleaned automatically, see /etc/apt/apt.conf.d/docker-clean
 
 COPY racetrack_client/setup.py racetrack_client/requirements.txt racetrack_client/README.md /src/racetrack_client/

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.9-slim-bullseye
 
 WORKDIR /src/dashboard
 
-RUN apt-get update -y && apt-get install -y postgresql-client
+RUN apt-get update -y && apt-get install -y postgresql-client \
+  curl dnsutils vim
 # apt cache is cleaned automatically, see /etc/apt/apt.conf.d/docker-clean
 
 COPY racetrack_client/setup.py racetrack_client/requirements.txt racetrack_client/README.md /src/racetrack_client/

--- a/image_builder/Dockerfile
+++ b/image_builder/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update -y && apt-get install -y \
     curl \
     gnupg \
     lsb-release \
-    git
+    git \
+    dnsutils \
+    vim
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
     echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \

--- a/image_builder/Dockerfile
+++ b/image_builder/Dockerfile
@@ -14,7 +14,8 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
     echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
-    apt-get update -y && apt-get install -y docker-ce-cli
+    apt-get update -y && apt-get install -y docker-ce-cli &&\
+    rm -rf /var/lib/apt/lists/*
 # apt cache is cleaned automatically, see /etc/apt/apt.conf.d/docker-clean
 
 RUN mkdir -p -m 777 /var/log/racetrack/image-builder/build-logs /src/workspaces /.docker

--- a/lifecycle/Dockerfile
+++ b/lifecycle/Dockerfile
@@ -15,7 +15,9 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
     echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
-    apt-get update -y && apt-get install -y docker-ce-cli
+    apt-get update -y && apt-get install -y docker-ce-cli &&\
+    rm -rf /var/lib/apt/lists/*
+# apt cache is cleaned automatically, see /etc/apt/apt.conf.d/docker-clean
 
 # install kubectl
 RUN curl -L "https://dl.k8s.io/release/v1.24.3/bin/linux/amd64/kubectl" \

--- a/lifecycle/Dockerfile
+++ b/lifecycle/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -y && apt-get install -y \
     gnupg \
     lsb-release \
     git \
+    dnsutils \
     vim
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
     echo \


### PR DESCRIPTION
`dnsutils` and `curl` binaries are pretty useful when debugging DNS / network issues inside containers. Since the containers run on non-root user, it comes in handy to ship the images with these packages.