### PR TITLE
Regenerate auth tokens on demand

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -156,6 +156,17 @@ tool to restore the database.
 Otherwise, if your database runs inside kubernetes, 
 exec to `postgres` pod and use [pg_restore](https://www.postgresql.org/docs/current/app-pgrestore.html). 
 
+##### Rotating Auth Key
+If you restore a snapshot of the Racetrack's database originating from the other environment (with different `AUTH_KEY`),
+it can invalidate the auth tokens, making the signature invalid with the current `AUTH_KEY`.
+In this case, once the migration is done, do the following:
+
+- Exec into the `lifecycle-supervisor` pod/container
+- Run `python -m lifecycle generate-auth admin` to create a valid Auth token for you. Copy it.
+- Go to Lifecycle-Supervisor or Lifecycle API page (`/lifecycle`) and Authorize with your Racetrack Auth Token.
+- Call endpoints `POST /api/v1/auth/token/user/regenerate` and `POST /api/v1/auth/token/fatman_family/regenerate`
+  to recreate valid signatures for the tokens.
+
 ### Plugins Volume
 Plugins are stored in a Persistent Volume called `racetrack-plugins-pvc`.
 Copy all of its contents with the help of your Kubernetes Admin.

--- a/lifecycle/lifecycle/auth/subject.py
+++ b/lifecycle/lifecycle/auth/subject.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 from django.contrib.auth.models import User
+from django.db.models import Q
 
 from lifecycle.django.registry.database import db_access
 from lifecycle.django.registry import models
@@ -133,3 +134,27 @@ def _get_subject_name_from_auth_subject(auth_subject: models.AuthSubject) -> str
         return auth_subject.fatman_family.name
     else:
         raise ValueError("Unknown auth_subject type")
+
+
+def regenerate_all_user_tokens():
+    auth_subject_queryset = models.AuthSubject.objects.filter(Q(user__isnull=False))
+    for auth_subject in auth_subject_queryset:
+        regenerate_auth_token(auth_subject)
+    count = auth_subject_queryset.count()
+    logger.info(f'Regenerated tokens of all {count} Users')
+
+
+def regenerate_all_fatman_family_tokens():
+    auth_subject_queryset = models.AuthSubject.objects.filter(Q(fatman_family__isnull=False))
+    for auth_subject in auth_subject_queryset:
+        regenerate_auth_token(auth_subject)
+    count = auth_subject_queryset.count()
+    logger.info(f'Regenerated tokens of all {count} Fatman Families')
+
+
+def regenerate_all_esc_tokens():
+    auth_subject_queryset = models.AuthSubject.objects.filter(Q(esc__isnull=False))
+    for auth_subject in auth_subject_queryset:
+        regenerate_auth_token(auth_subject)
+    count = auth_subject_queryset.count()
+    logger.info(f'Regenerated tokens of all {count} ESCs')

--- a/lifecycle/lifecycle/endpoints/auth.py
+++ b/lifecycle/lifecycle/endpoints/auth.py
@@ -3,7 +3,7 @@ from fastapi.responses import Response, JSONResponse
 
 from lifecycle.auth.authenticate import authenticate_token
 from lifecycle.auth.authorize import authorize_internal_token, authorize_resource_access, grant_permission
-from lifecycle.auth.subject import get_auth_subject_by_esc, get_auth_subject_by_fatman_family
+from lifecycle.auth.subject import get_auth_subject_by_esc, get_auth_subject_by_fatman_family, regenerate_all_esc_tokens, regenerate_all_fatman_family_tokens, regenerate_all_user_tokens
 from lifecycle.config import Config
 from lifecycle.auth.check import check_auth
 from lifecycle.fatman.esc import read_esc_model
@@ -79,3 +79,22 @@ def setup_auth_endpoints(api: APIRouter, config: Config):
         esc_model = read_esc_model(esc_id)
         auth_subject = get_auth_subject_by_esc(esc_model)
         return {'token': auth_subject.token}
+
+    @api.post('/auth/token/user/regenerate')
+    def _generate_tokens_for_all_users(request: Request):
+        """Generate new tokens for all Users"""
+        check_auth(request, scope=AuthScope.CALL_ADMIN_API)
+        regenerate_all_user_tokens()
+        
+    @api.post('/auth/token/fatman_family/regenerate')
+    def _generate_tokens_for_all_fatman_families(request: Request):
+        """Generate new tokens for all Fatman Families"""
+        check_auth(request, scope=AuthScope.CALL_ADMIN_API)
+        regenerate_all_fatman_family_tokens()
+        
+    @api.post('/auth/token/esc/regenerate')
+    def _generate_tokens_for_all_escs(request: Request):
+        """Generate new tokens for all ESCs"""
+        check_auth(request, scope=AuthScope.CALL_ADMIN_API)
+        regenerate_all_esc_tokens()
+        

--- a/racetrack_commons/racetrack_commons/auth/token.py
+++ b/racetrack_commons/racetrack_commons/auth/token.py
@@ -78,7 +78,7 @@ def generate_service_token(
 def generate_internal_token(
     subject_name: str, 
     signature_key: str, 
-    scopes: AuthScope = [AuthScope.FULL_ACCESS],
+    scopes: List[AuthScope] = [AuthScope.FULL_ACCESS],
 ) -> str:
     """Generate an auth token for internal Racetrack service to communicate with Lifecycle API"""
     payload = AuthTokenPayload(


### PR DESCRIPTION
When you restore the snapshot of the Racetrack's database originating from the other environment (with other `AUTH_KEY`), it can break down the tokens, making the signature invalid with the current `AUTH_KEY`. Thus, we need an endpoint for admins to recreate the signatures of all tokens.

In particular, migration from v1 to v2 goes through the `lifecycle/lifecycle/django/registry/migrations/0021_migrate_permissions.py` which depends on the current value of `AUTH_KEY`. So if it was changed after the migration, it might cause a malfunction.