### PR TITLE
Fix typo in title

### DIFF
--- a/dashboard/dashboard/templates/racetrack/base.html
+++ b/dashboard/dashboard/templates/racetrack/base.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ site_name_prefix }}Ractrack Dashboard</title>
+    <title>{{ site_name_prefix }}Racetrack Dashboard</title>
     {% load static %}
     <link href="{% static 'racetrack/bootstrap.min.css' %}" rel="stylesheet" type="text/css"/>
     <link href="{% static 'racetrack/styles.css' %}" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Fixes typo on Dashboard: **Ractrack Dashboard** => **Racetrack Dashboard**