### PR TITLE
Set mode 600 on racetrack config file

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Racetrack client keeps the local config file `~/.racetrack/config.yaml` with mode `600`
+  (not readable by others) and warns you if this file has insecure permissions
+  since it may contain credentials.
 
 ## [2.9.1] - 2023-02-20
 ### Changed

--- a/racetrack_client/racetrack_client/client_config/io.py
+++ b/racetrack_client/racetrack_client/client_config/io.py
@@ -57,3 +57,7 @@ def _check_file_mode(config_path: Path):
         logger.warning(f'Config file {config_path} is readable by others! Change permissions to 600.')
     elif file_mode & stat.S_IRGRP:
         logger.warning(f'Config file {config_path} is readable by group! Change permissions to 600.')
+    elif file_mode & stat.S_IWOTH:
+        logger.warning(f'Config file {config_path} is writable by others! Change permissions to 600.')
+    elif file_mode & stat.S_IWGRP:
+        logger.warning(f'Config file {config_path} is writable by group! Change permissions to 600.')

--- a/racetrack_client/racetrack_client/client_config/io.py
+++ b/racetrack_client/racetrack_client/client_config/io.py
@@ -42,5 +42,6 @@ def save_client_config(config: ClientConfig):
     dir_path.mkdir(parents=True, exist_ok=True)
     config_path = dir_path / 'config.yaml'
 
-    with open(config_path, 'w') as outfile:
-        yaml.dump(data_dict, outfile)
+    yaml_content = yaml.dump(data_dict)
+    config_path.write_text(yaml_content)
+    config_path.chmod(0o600)


### PR DESCRIPTION
It sets mode 600 each time the config is rewritten. So the existing files will be fixed once any configuration change happens, eg. `racetrack set remote ...`

@blackplague  I can't set you as a reviewer, but please take a look.