### PR TITLE
Add job type column to racetrack client list command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New column in the *list* command of the Racetrack client displays a job type.
+  Try it out by running `racetrack list -c job_type`.
+  [issue #207](https://github.com/TheRacetrack/racetrack/issues/207)
+
+### Changed
+- The *list* command of the Racetrack client drops the fancy formatting and *INFO*/*DEBUG* logs
+  when being piped into another command (ie. not connected to a terminal/tty device). Try `racetrack list | cat`.
+  [issue #207](https://github.com/TheRacetrack/racetrack/issues/207)
 
 ## [2.11.0] - 2023-03-17
 ### Added

--- a/racetrack_client/racetrack_client/client/manage.py
+++ b/racetrack_client/racetrack_client/client/manage.py
@@ -1,10 +1,11 @@
 from enum import Enum
+import sys
 from typing import Dict, List, Optional
 
 from racetrack_client.client_config.alias import resolve_lifecycle_url
 from racetrack_client.client_config.auth import get_user_auth
 from racetrack_client.client_config.io import load_client_config
-from racetrack_client.log.logs import get_logger
+from racetrack_client.log.logs import configure_logs, get_logger
 from racetrack_client.utils.auth import get_auth_request_headers
 from racetrack_client.utils.request import parse_response, parse_response_list, Requests
 from racetrack_client.utils.table import print_table
@@ -26,6 +27,9 @@ class JobTableColumn(str, Enum):
 
 def list_jobs(remote: Optional[str], columns: List[JobTableColumn]):
     """List all deployed jobs"""
+    if not sys.stdout.isatty():
+        configure_logs(log_level='error')
+
     client_config = load_client_config()
     lifecycle_url = resolve_lifecycle_url(client_config, remote)
     user_auth = get_user_auth(client_config, lifecycle_url)

--- a/racetrack_client/racetrack_client/client/manage.py
+++ b/racetrack_client/racetrack_client/client/manage.py
@@ -61,10 +61,10 @@ def list_jobs(remote: Optional[str], columns: List[JobTableColumn]):
         status = job.get('status', '').upper()
         cells = [name, version, status]
 
-        if JobTableColumn.infrastructure in columns or JobTableColumn.all in columns:
-            cells.append(job.get('infrastructure_target'))
         if JobTableColumn.job_type in columns or JobTableColumn.all in columns:
             cells.append(job.get('job_type_version'))
+        if JobTableColumn.infrastructure in columns or JobTableColumn.all in columns:
+            cells.append(job.get('infrastructure_target'))
         if JobTableColumn.deployed_by in columns or JobTableColumn.all in columns:
             cells.append(job.get('deployed_by'))
         if JobTableColumn.updated_at in columns or JobTableColumn.all in columns:

--- a/racetrack_client/racetrack_client/client/manage.py
+++ b/racetrack_client/racetrack_client/client/manage.py
@@ -15,6 +15,7 @@ logger = get_logger(__name__)
 
 
 class JobTableColumn(str, Enum):
+    job_type = "job_type"
     infrastructure = "infrastructure"
     deployed_by = "deployed_by"
     updated_at = "updated_at"
@@ -40,6 +41,8 @@ def list_jobs(remote: Optional[str], columns: List[JobTableColumn]):
         return
 
     header = ['NAME', 'VERSION', 'STATUS']
+    if JobTableColumn.job_type in columns or JobTableColumn.all in columns:
+        header.append('JOB TYPE')
     if JobTableColumn.infrastructure in columns or JobTableColumn.all in columns:
         header.append('INFRASTRUCTURE')
     if JobTableColumn.deployed_by in columns or JobTableColumn.all in columns:
@@ -60,6 +63,8 @@ def list_jobs(remote: Optional[str], columns: List[JobTableColumn]):
 
         if JobTableColumn.infrastructure in columns or JobTableColumn.all in columns:
             cells.append(job.get('infrastructure_target'))
+        if JobTableColumn.job_type in columns or JobTableColumn.all in columns:
+            cells.append(job.get('job_type_version'))
         if JobTableColumn.deployed_by in columns or JobTableColumn.all in columns:
             cells.append(job.get('deployed_by'))
         if JobTableColumn.updated_at in columns or JobTableColumn.all in columns:

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -1,4 +1,5 @@
 from typing import List
+
 import typer
 
 from racetrack_client import __version__
@@ -39,7 +40,7 @@ def main():
 def _startup(
     verbose: bool = typer.Option(False, '-v', '--verbose', help='enable verbose mode'),
 ):
-    configure_logs(verbosity=1 if verbose else 0)
+    configure_logs(log_level='debug' if verbose else 'info')
 
 
 @cli.command('deploy')


### PR DESCRIPTION
### Added
- New column in the *list* command of the Racetrack client displays a job type.
  Try it out by running `racetrack list -c job_type`.

### Changed
- The *list* command of the Racetrack client drops the fancy formatting and *INFO*/*DEBUG* logs
  when being piped into another command (ie. not connected to a terminal/tty device). Try `racetrack list | cat`.