### PR TITLE
Add "perform" command to call a job with CLI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [issue #207](https://github.com/TheRacetrack/racetrack/issues/207)
 - New command `racetrack perform NAME PAYLOAD [--version VERSION] [--remote REMOTE] [--endpoint ENDPOINT] [--curl]`
   allows you to call an endpoint of a job.
-  Provide the name of the job and the payload of the request in JSON or YAML format.
-  For example: `racetrack perform adder '{"numbers": [40,2]}'`.
-  Use `--curl` flag if you want to generate a curl query instead of calling the job.
+  Provide the name of the job and the payload of the request in JSON or YAML format,
+  for example `racetrack perform adder '{"numbers": [40,2]}'`.
+  Use `--curl` flag, if you want to generate a curl query instead of calling the job.
   Check out `racetrack perform --help` for more details.
   [issue #146](https://github.com/TheRacetrack/racetrack/issues/146)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Use `--curl` flag, if you want to generate a curl query instead of calling the job.
   Check out `racetrack call --help` for more details.
   [issue #146](https://github.com/TheRacetrack/racetrack/issues/146)
+- Name of the job can be autocompleted by hitting `Tab` while typing a CLI command.
+  Remember to run `racetrack --install-completion` beforehand.
+  Under the hood, it fetches the available jobs from the current remote.
 
 ### Changed
 - The *list* command of the Racetrack client drops the fancy formatting and *INFO*/*DEBUG* logs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New column in the *list* command of the Racetrack client displays a job type.
   Try it out by running `racetrack list -c job_type`.
   [issue #207](https://github.com/TheRacetrack/racetrack/issues/207)
-- New command `racetrack perform NAME PAYLOAD [--version VERSION] [--remote REMOTE] [--endpoint ENDPOINT] [--curl]`
+- New command `racetrack call NAME ENDPOINT PAYLOAD [--version VERSION] [--remote REMOTE] [--curl]`
   allows you to call an endpoint of a job.
   Provide the name of the job and the payload of the request in JSON or YAML format,
-  for example `racetrack perform adder '{"numbers": [40,2]}'`.
+  for example `racetrack call adder /api/v1/perform '{"numbers": [40,2]}'`.
   Use `--curl` flag, if you want to generate a curl query instead of calling the job.
-  Check out `racetrack perform --help` for more details.
+  Check out `racetrack call --help` for more details.
   [issue #146](https://github.com/TheRacetrack/racetrack/issues/146)
 
 ### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New column in the *list* command of the Racetrack client displays a job type.
   Try it out by running `racetrack list -c job_type`.
   [issue #207](https://github.com/TheRacetrack/racetrack/issues/207)
+- New command `racetrack perform NAME PAYLOAD [--version VERSION] [--remote REMOTE] [--endpoint ENDPOINT] [--curl]`
+  allows you to call an endpoint of a job.
+  Provide the name of the job and the payload of the request in JSON or YAML format.
+  For example: `racetrack perform adder '{"numbers": [40,2]}'`.
+  Use `--curl` flag if you want to generate a curl query instead of calling the job.
+  Check out `racetrack perform --help` for more details.
+  [issue #146](https://github.com/TheRacetrack/racetrack/issues/146)
 
 ### Changed
 - The *list* command of the Racetrack client drops the fancy formatting and *INFO*/*DEBUG* logs

--- a/racetrack_client/racetrack_client/client/call.py
+++ b/racetrack_client/racetrack_client/client/call.py
@@ -35,6 +35,8 @@ def call_job(
     )
     job = parse_response_object(r, 'Lifecycle response error')
     pub_url = job.get('pub_url')
+    if not endpoint.startswith('/'):
+        endpoint = '/' + endpoint
     full_url = f'{pub_url}{endpoint}'
     payload_dict = _parse_payload(payload)
 

--- a/racetrack_client/racetrack_client/client/call.py
+++ b/racetrack_client/racetrack_client/client/call.py
@@ -1,10 +1,12 @@
 import json
-import sys
 from typing import Dict, Optional
+
+import yaml
 
 from racetrack_client.client_config.alias import resolve_lifecycle_url
 from racetrack_client.client_config.auth import get_user_auth
 from racetrack_client.client_config.io import load_client_config
+from racetrack_client.log.context_error import wrap_context
 from racetrack_client.log.logs import configure_logs, get_logger
 from racetrack_client.utils.auth import get_auth_request_headers
 from racetrack_client.utils.request import parse_response, parse_response_object, Requests
@@ -17,7 +19,7 @@ def call_job(
     version: str,
     remote: Optional[str],
     endpoint: str,
-    payload_json: str,
+    payload: str,
     curl: bool,
 ):
     if curl:
@@ -33,11 +35,11 @@ def call_job(
     )
     job = parse_response_object(r, 'Lifecycle response error')
     pub_url = job.get('pub_url')
-    payload_dict = json.loads(payload_json)
     full_url = f'{pub_url}{endpoint}'
+    payload_dict = _parse_payload(payload)
 
     if curl:
-        _print_curl_command(name, version, full_url, payload_json, user_auth)
+        _print_curl_command(full_url, payload_dict, user_auth)
         return
 
     logger.info(f'Calling job "{name} {version}" at {full_url}')
@@ -46,23 +48,34 @@ def call_job(
         json=payload_dict,
         headers=get_auth_request_headers(user_auth),
     )
-    response_object = parse_response(r, 'Lifecycle response error')
-    logger.info('Result:')
-    print(str(response_object))
 
+    response_object = parse_response(r, 'Lifecycle response error')
+    logger.info('Response:')
+    response_str = json.dumps(response_object, indent=4)
+    print(response_str)
+
+
+def _parse_payload(payload: str) -> Dict:
+    with wrap_context('parsing payload'):
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            obj = yaml.load(payload, Loader=yaml.FullLoader)
+        assert isinstance(obj, dict), 'given payload is not a key-value dictionary'
+        return obj
+        
 
 def _print_curl_command(
-    name: str,
-    version: str,
     full_url: str,
-    payload_json: str,
+    payload_dict: Dict,
     user_auth: str,
 ):
+    payload_json = json.dumps(payload_dict, indent=2)
     print(f"""
     curl -X 'POST' \\
   '{full_url}' \\
   -H 'X-Racetrack-Auth: {user_auth}' \\
   -H 'Accept: application/json' \\
-  -H 'Content-Type: application/json' \\
+  -H 'Content-Type: application/json; charset=utf-8' \\
   -d '{payload_json}'
 """.strip())

--- a/racetrack_client/racetrack_client/client/call.py
+++ b/racetrack_client/racetrack_client/client/call.py
@@ -1,0 +1,68 @@
+import json
+import sys
+from typing import Dict, Optional
+
+from racetrack_client.client_config.alias import resolve_lifecycle_url
+from racetrack_client.client_config.auth import get_user_auth
+from racetrack_client.client_config.io import load_client_config
+from racetrack_client.log.logs import configure_logs, get_logger
+from racetrack_client.utils.auth import get_auth_request_headers
+from racetrack_client.utils.request import parse_response, parse_response_object, Requests
+
+logger = get_logger(__name__)
+
+
+def call_job(
+    name: str,
+    version: str,
+    remote: Optional[str],
+    endpoint: str,
+    payload_json: str,
+    curl: bool,
+):
+    if curl:
+        configure_logs(log_level='error')
+
+    client_config = load_client_config()
+    lifecycle_url = resolve_lifecycle_url(client_config, remote)
+    user_auth = get_user_auth(client_config, lifecycle_url)
+
+    r = Requests.get(
+        f'{lifecycle_url}/api/v1/job/{name}/{version}',
+        headers=get_auth_request_headers(user_auth),
+    )
+    job = parse_response_object(r, 'Lifecycle response error')
+    pub_url = job.get('pub_url')
+    payload_dict = json.loads(payload_json)
+    full_url = f'{pub_url}{endpoint}'
+
+    if curl:
+        _print_curl_command(name, version, full_url, payload_json, user_auth)
+        return
+
+    logger.info(f'Calling job "{name} {version}" at {full_url}')
+    r = Requests.post(
+        full_url,
+        json=payload_dict,
+        headers=get_auth_request_headers(user_auth),
+    )
+    response_object = parse_response(r, 'Lifecycle response error')
+    logger.info('Result:')
+    print(str(response_object))
+
+
+def _print_curl_command(
+    name: str,
+    version: str,
+    full_url: str,
+    payload_json: str,
+    user_auth: str,
+):
+    print(f"""
+    curl -X 'POST' \\
+  '{full_url}' \\
+  -H 'X-Racetrack-Auth: {user_auth}' \\
+  -H 'Accept: application/json' \\
+  -H 'Content-Type: application/json' \\
+  -d '{payload_json}'
+""".strip())

--- a/racetrack_client/racetrack_client/client/manage.py
+++ b/racetrack_client/racetrack_client/client/manage.py
@@ -1,5 +1,4 @@
 from enum import Enum
-import sys
 from typing import Dict, List, Optional
 
 from racetrack_client.client_config.alias import resolve_lifecycle_url
@@ -27,9 +26,6 @@ class JobTableColumn(str, Enum):
 
 def list_jobs(remote: Optional[str], columns: List[JobTableColumn]):
     """List all deployed jobs"""
-    if not sys.stdout.isatty():
-        configure_logs(log_level='error')
-
     client_config = load_client_config()
     lifecycle_url = resolve_lifecycle_url(client_config, remote)
     user_auth = get_user_auth(client_config, lifecycle_url)

--- a/racetrack_client/racetrack_client/client/manage.py
+++ b/racetrack_client/racetrack_client/client/manage.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 from racetrack_client.client_config.alias import resolve_lifecycle_url
 from racetrack_client.client_config.auth import get_user_auth
 from racetrack_client.client_config.io import load_client_config
-from racetrack_client.log.logs import configure_logs, get_logger
+from racetrack_client.log.logs import get_logger
 from racetrack_client.utils.auth import get_auth_request_headers
 from racetrack_client.utils.request import parse_response, parse_response_list, Requests
 from racetrack_client.utils.table import print_table
@@ -115,3 +115,24 @@ def delete_job(name: str, version: str, remote: Optional[str]):
     )
     parse_response(r, 'Lifecycle response error')
     logger.info(f'Job "{name}" v{version} has been deleted from {lifecycle_url}')
+
+
+def complete_job_name(incomplete: str) -> List[str]:
+    """Return list of possible completions based on incomplete job name"""
+    completion = []
+
+    client_config = load_client_config()
+    lifecycle_url = resolve_lifecycle_url(client_config, None)
+    user_auth = get_user_auth(client_config, lifecycle_url)
+
+    r = Requests.get(
+        f'{lifecycle_url}/api/v1/job',
+        headers=get_auth_request_headers(user_auth),
+    )
+    jobs: List[Dict] = parse_response_list(r, 'Lifecycle response error')
+    job_names = [job.get('name') for job in jobs]
+
+    for name in job_names:
+        if name.startswith(incomplete):
+            completion.append(name)
+    return completion

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -251,7 +251,7 @@ def _plugin_bundle(
 @cli.command('perform', no_args_is_help=True)
 def _call_job(
     name: str = typer.Argument(..., show_default=False, help='name of the job'),
-    payload: str = typer.Argument('{}', show_default=True, help='JSON payload of the request'),
+    payload: str = typer.Argument(..., show_default=False, help='payload of the request in JSON or YAML format'),
     version: str = typer.Option('latest', show_default=True, help='version of the job'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
     endpoint: str = typer.Option('/api/v1/perform', show_default=True, help='endpoint of the job to call'),

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -6,7 +6,7 @@ import typer
 from racetrack_client import __version__
 from racetrack_client.client.call import call_job
 from racetrack_client.client.deploy import BuildContextMethod, send_deploy_request, DeploymentError
-from racetrack_client.client.manage import JobTableColumn, move_job, delete_job, list_jobs
+from racetrack_client.client.manage import JobTableColumn, move_job, delete_job, list_jobs, complete_job_name
 from racetrack_client.client.logs import show_runtime_logs, show_build_logs
 from racetrack_client.client.run import run_job_locally
 from racetrack_client.client_config.auth import login_user_auth, logout_user_auth
@@ -28,6 +28,7 @@ cli = typer.Typer(
     name='racetrack',
     help='CLI client tool for managing workloads in Racetrack',
 )
+
 
 def main():
     try:
@@ -70,7 +71,7 @@ def _validate(
 
 @cli.command('logs', no_args_is_help=True)
 def _logs(
-    name: str = typer.Argument(..., show_default=False, help='name of the job'),
+    name: str = typer.Argument(..., show_default=False, help='name of the job', autocompletion=complete_job_name),
     version: str = typer.Option('latest', show_default=True, help='version of the job'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
     tail: int = typer.Option(20, '--tail', help='number of recent lines to show'),
@@ -82,7 +83,7 @@ def _logs(
 
 @cli.command('build-logs', no_args_is_help=True)
 def _build_logs(
-    name: str = typer.Argument(..., show_default=False, help='name of the job'),
+    name: str = typer.Argument(..., show_default=False, help='name of the job', autocompletion=complete_job_name),
     version: str = typer.Option('latest', show_default=True, help='version of the job'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
     tail: int = typer.Option(0, '--tail', help='number of recent lines to show, all logs by default'),
@@ -102,7 +103,7 @@ def _list_jobs(
 
 @cli.command('delete', no_args_is_help=True)
 def _delete_job(
-    name: str = typer.Argument(..., show_default=False, help='name of the job'),
+    name: str = typer.Argument(..., show_default=False, help='name of the job', autocompletion=complete_job_name),
     version: str = typer.Option(..., show_default=False, help='version of the job to delete'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
 ):
@@ -112,7 +113,7 @@ def _delete_job(
 
 @cli.command('move', no_args_is_help=True)
 def _move_job(
-    name: str = typer.Argument(..., show_default=False, help='name of the job'),
+    name: str = typer.Argument(..., show_default=False, help='name of the job', autocompletion=complete_job_name),
     version: str = typer.Option(..., show_default=False, help='version of the job to move out'),
     infrastructure: str = typer.Option(..., show_default=False, help='infrastructure target to move to'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
@@ -159,6 +160,7 @@ def _logout(
 cli_set = typer.Typer(no_args_is_help=True, help='Set global options of the Racetrack client')
 cli.add_typer(cli_set, name="set")
 
+
 @cli_set.command('remote', no_args_is_help=True)
 def _set_remote(
     remote: str = typer.Argument(..., show_default=False, help="Racetrack server's URL or alias name"),
@@ -190,6 +192,7 @@ def _set_alias(
 cli_get = typer.Typer(no_args_is_help=True, help='Read global options of the Racetrack client')
 cli.add_typer(cli_get, name="get")
 
+
 @cli_get.command('remote')
 def _get_remote():
     """Get current Racetrack's remote address"""
@@ -206,6 +209,7 @@ def _get_config():
 # racetrack plugin ...
 cli_plugin = typer.Typer(no_args_is_help=True, help='Manage Racetrack plugins')
 cli.add_typer(cli_plugin, name="plugin")
+
 
 @cli_plugin.command('install', no_args_is_help=True)
 def _install_plugin(
@@ -250,7 +254,7 @@ def _plugin_bundle(
 
 @cli.command('call', no_args_is_help=True)
 def _call_job(
-    name: str = typer.Argument(..., show_default=False, help='name of the job'),
+    name: str = typer.Argument(..., show_default=False, help='name of the job', autocompletion=complete_job_name),
     endpoint: str = typer.Argument(..., show_default=False, help='endpoint of the job to call, eg. /api/v1/perform'),
     payload: str = typer.Argument(..., show_default=False, help='payload of the request in JSON or YAML format'),
     version: str = typer.Option('latest', show_default=True, help='version of the job'),

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -248,13 +248,13 @@ def _plugin_bundle(
     bundle_plugin(workdir, out, plugin_version)
 
 
-@cli.command('perform', no_args_is_help=True)
+@cli.command('call', no_args_is_help=True)
 def _call_job(
     name: str = typer.Argument(..., show_default=False, help='name of the job'),
+    endpoint: str = typer.Argument(..., show_default=False, help='endpoint of the job to call, eg. /api/v1/perform'),
     payload: str = typer.Argument(..., show_default=False, help='payload of the request in JSON or YAML format'),
     version: str = typer.Option('latest', show_default=True, help='version of the job'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
-    endpoint: str = typer.Option('/api/v1/perform', show_default=True, help='endpoint of the job to call'),
     curl: bool = typer.Option(False, '--curl', help='generate a curl query instead of calling the job'),
 ):
     """Call an endpoint of a job"""


### PR DESCRIPTION
- New command `racetrack call NAME ENDPOINT PAYLOAD [--version VERSION] [--remote REMOTE] [--curl]`
  allows you to call an endpoint of a job.
  Provide the name of the job and the payload of the request in JSON or YAML format,
  for example `racetrack call adder /api/v1/perform '{"numbers": [40,2]}'`.
  Use `--curl` flag, if you want to generate a curl query instead of calling the job.
  Check out `racetrack call --help` for more details.
- Name of the job can be autocompleted by hitting `Tab` while typing a CLI command.
  Remember to run `racetrack --install-completion` beforehand.
  Under the hood, it fetches the available jobs from the current remote.