### PR TITLE
Allow setting cookie on non-HTTPS deployments

### DIFF
--- a/dashboard/dashboard/middleware.py
+++ b/dashboard/dashboard/middleware.py
@@ -53,6 +53,7 @@ class UserCookieMiddleWare(object):
 def set_auth_token_cookie(auth_token: str, response: HttpResponse):
     # if cookie value contains /, it would get unnecessarily double quoted, so encode
     value = quote(auth_token, safe="")
+    secure_cookie: bool = os.environ.get('ENFORCE_SECURE_COOKIE', 'false').lower() == 'true'
 
     # Domain defines the host to which the cookie will be sent.
     # Empty domain means that cookie will be created for current host, not including subdomains.
@@ -65,7 +66,7 @@ def set_auth_token_cookie(auth_token: str, response: HttpResponse):
         max_age=60 * 60 * 24 * 31,  # one month of cookie lifetime (in seconds), also makes cookie persist between browser restarts
         samesite='lax',  # cookie is sent only when user access origin site or navigates to it, prevents CSRF
         httponly=True,  # prevents client-side JavaScript read access
-        secure=False)  # cookie is sent only when request is made with https (except on localhost)
+        secure=secure_cookie)  # whether cookie may only be transmitted using a secure https connection (except on localhost)
 
 
 def _get_cookie_domain() -> str | None:

--- a/dashboard/dashboard/middleware.py
+++ b/dashboard/dashboard/middleware.py
@@ -24,11 +24,6 @@ class UserCookieMiddleWare(object):
     def __call__(self, request):
         response = self.get_response(request)
 
-        cookie_domain = os.environ.get('CLUSTER_FQDN', None)
-        if cookie_domain:
-            racetrack_subdomain = os.environ.get('RACETRACK_SUBDOMAIN', 'racetrack')
-            cookie_domain = f'{racetrack_subdomain}.{cookie_domain}'
-
         try:
             user_authenticated = request.user.is_authenticated
         except OperationalError as e:
@@ -42,7 +37,7 @@ class UserCookieMiddleWare(object):
             if auth_token is None:
                 logging.error("UserCookieMiddleware: user_auth from session is empty")
                 return response
-        
+
             set_auth_token_cookie(auth_token, response)
 
         elif not user_authenticated:
@@ -70,7 +65,7 @@ def set_auth_token_cookie(auth_token: str, response: HttpResponse):
         max_age=60 * 60 * 24 * 31,  # one month of cookie lifetime (in seconds), also makes cookie persist between browser restarts
         samesite='lax',  # cookie is sent only when user access origin site or navigates to it, prevents CSRF
         httponly=True,  # prevents client-side JavaScript read access
-        secure=True)  # cookie is sent only when request is made with https (except on localhost)
+        secure=False)  # cookie is sent only when request is made with https (except on localhost)
 
 
 def _get_cookie_domain() -> str | None:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Remember to run `racetrack --install-completion` beforehand.
   Under the hood, it fetches the available jobs from the current remote.
 
+### Fixed
+- Racetrack's cookie can work even on non-HTTPS deployments.
+  [issue #225](https://github.com/TheRacetrack/racetrack/issues/225)
+
 ### Changed
 - The *list* command of the Racetrack client drops the fancy formatting and *INFO*/*DEBUG* logs
   when being piped into another command (ie. not connected to a terminal/tty device). Try `racetrack list | cat`.


### PR DESCRIPTION
Racetrack's cookie can work even on non-HTTPS deployments, eg. AKS