### PR TITLE
Minor UI improvements for a Dashboard

### DIFF
--- a/dashboard/dashboard-front/src/App.vue
+++ b/dashboard/dashboard-front/src/App.vue
@@ -30,7 +30,7 @@ progressService.init(progressCompononent)
     <NavDrawer ref="navDrawer"/>
 
     <q-page-container>
-      <div id="app-container">
+      <div class="app-container-full">
         <RouterView />
       </div>
     </q-page-container>

--- a/dashboard/dashboard-front/src/assets/main.css
+++ b/dashboard/dashboard-front/src/assets/main.css
@@ -1,7 +1,10 @@
-#app-container {
+.app-container-full {
+  padding: 2rem;
+}
+
+.app-container {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
 }
 
 .x-monospace {

--- a/dashboard/dashboard-front/src/components/NavDrawer.vue
+++ b/dashboard/dashboard-front/src/components/NavDrawer.vue
@@ -22,7 +22,7 @@ defineExpose({
     side="left"
     bordered
     v-if="isAuthenticated"
-    width="250"
+    :width="250"
   >
     <q-scroll-area class="fit">
       <q-list padding class="text-grey-8">

--- a/dashboard/dashboard-front/src/components/NavDrawer.vue
+++ b/dashboard/dashboard-front/src/components/NavDrawer.vue
@@ -22,7 +22,7 @@ defineExpose({
     side="left"
     bordered
     v-if="isAuthenticated"
-    :width="250"
+    :width="220"
   >
     <q-scroll-area class="fit">
       <q-list padding class="text-grey-8">

--- a/dashboard/dashboard-front/src/components/NavDrawer.vue
+++ b/dashboard/dashboard-front/src/components/NavDrawer.vue
@@ -22,6 +22,7 @@ defineExpose({
     side="left"
     bordered
     v-if="isAuthenticated"
+    width="250"
   >
     <q-scroll-area class="fit">
       <q-list padding class="text-grey-8">

--- a/dashboard/dashboard-front/src/components/account/LoginView.vue
+++ b/dashboard/dashboard-front/src/components/account/LoginView.vue
@@ -72,9 +72,9 @@ function clearCredentials() {
 
       <h5 class="text-h5 q-my-sm text-center text-grey-9">Sign In</h5>
 
-      <q-card-section>
-        <q-form class="q-gutter-md">
-          <q-input outlined autofocus type="email" label="Email" autocomplete="username"
+      <q-form autocomple="on" @submit.prevent="login">
+        <q-card-section class="q-gutter-md">
+          <q-input outlined autofocus type="text" label="Email" autocomplete="username"
             v-model="username" @keydown.enter.prevent="login"
             >
             <template v-if="username" v-slot:append>
@@ -84,12 +84,12 @@ function clearCredentials() {
           <q-input outlined type="password" label="Password" autocomplete="password"
             v-model="password" @keydown.enter.prevent="login"
             />
-        </q-form>
-      </q-card-section>
-      <q-card-actions class="q-px-md">
-        <q-btn color="primary" size="lg" class="full-width" label="Login" push
-          :loading="loading" @click="login" />
-      </q-card-actions>
+        </q-card-section>
+        <q-card-actions class="q-px-md">
+          <q-btn color="primary" size="lg" class="full-width" label="Login" type="submit" push
+          :loading="loading" />
+        </q-card-actions>
+      </q-form>
       
       <q-separator class="q-ma-sm"/>
 

--- a/dashboard/dashboard-front/src/components/account/LoginView.vue
+++ b/dashboard/dashboard-front/src/components/account/LoginView.vue
@@ -67,7 +67,7 @@ function clearCredentials() {
 </script>
 
 <template>
-  <div class="row justify-center">
+  <div class="row justify-center app-container">
     <q-card bordered class="q-pa-lg shadow-1 col-xs-12 col-sm-6 col-md-5">
 
       <h5 class="text-h5 q-my-sm text-center text-grey-9">Sign In</h5>

--- a/dashboard/dashboard-front/src/components/account/LoginView.vue
+++ b/dashboard/dashboard-front/src/components/account/LoginView.vue
@@ -74,14 +74,14 @@ function clearCredentials() {
 
       <q-form autocomple="on" @submit.prevent="login">
         <q-card-section class="q-gutter-md">
-          <q-input outlined autofocus type="text" label="Email" autocomplete="username"
+          <q-input outlined autofocus type="text" label="Email" name="username" autocomplete="username"
             v-model="username" @keydown.enter.prevent="login"
             >
             <template v-if="username" v-slot:append>
               <q-icon name="cancel" @click.stop.prevent="clearCredentials" class="cursor-pointer" />
             </template>
           </q-input>
-          <q-input outlined type="password" label="Password" autocomplete="password"
+          <q-input outlined type="password" label="Password" name="password" autocomplete="password"
             v-model="password" @keydown.enter.prevent="login"
             />
         </q-card-section>

--- a/dashboard/dashboard-front/src/components/account/RegisterView.vue
+++ b/dashboard/dashboard-front/src/components/account/RegisterView.vue
@@ -45,6 +45,7 @@ function register() {
 </script>
 
 <template>
+    <div class="app-container">
     <q-card bordered class="q-pa-md full-width">
         
         <h5 class="text-h5 q-my-sm text-center text-grey-9">Create an account</h5>
@@ -84,4 +85,5 @@ function register() {
         </q-card-section>
         
     </q-card>
+    </div>
 </template>

--- a/dashboard/dashboard-front/src/components/account/ResetPasswordView.vue
+++ b/dashboard/dashboard-front/src/components/account/ResetPasswordView.vue
@@ -3,11 +3,15 @@
 </script>
 
 <template>
-    <div class="row justify-center">
+    <div class="row justify-center app-container">
       <q-card bordered class="q-pa-lg full-width">
 
         <h5 class="text-h5 q-my-sm text-center text-grey-9">Forgot Your Password?</h5>
         <p>Please contact your Racetrack administrator for help.</p>
+
+        <q-card-section class="text-center q-pa-none">
+            <p class="q-pt-sm"><router-link :to="{name: 'login'}" class="text-subtitle1 text-primary">Sign in</router-link></p>
+        </q-card-section>
 
       </q-card>
     </div>

--- a/dashboard/dashboard-front/src/components/admin/AdministrationView.vue
+++ b/dashboard/dashboard-front/src/components/admin/AdministrationView.vue
@@ -133,7 +133,7 @@ function onPluginUploaded(info: any) {
             
             <q-field outlined label="Lifecycle API server address" stack-label class="q-mt-md">
                 <template v-slot:control>
-                    <a :href="envInfo.lifecycle_url || ''" target="_blank" class="x-monospace x-overflow-any">
+                    <a :href="envInfo.lifecycle_url || ''" target="_blank" class="x-overflow-any">
                         {{ envInfo.lifecycle_url }}
                     </a>
                 </template>
@@ -144,12 +144,23 @@ function onPluginUploaded(info: any) {
             
             <q-field outlined label="Lifecycle Admin panel" stack-label class="q-mt-md">
                 <template v-slot:control>
-                    <a :href="lifecycleAdminUrl" target="_blank" class="x-monospace x-overflow-any">
+                    <a :href="lifecycleAdminUrl" target="_blank" class="x-overflow-any">
                         {{ lifecycleAdminUrl }}
                     </a>
                 </template>
                 <template v-slot:append>
                     <q-btn round dense flat icon="content_copy" @click="copyText(lifecycleAdminUrl)" />
+                </template>
+            </q-field>
+
+            <q-field outlined label="Grafana dashboards" stack-label class="q-mt-md">
+                <template v-slot:control>
+                    <a :href="envInfo.grafana_url" target="_blank" class="x-overflow-any">
+                        {{ envInfo.grafana_url }}
+                    </a>
+                </template>
+                <template v-slot:append>
+                    <q-btn round dense flat icon="content_copy" @click="copyText(envInfo.grafana_url)" />
                 </template>
             </q-field>
 

--- a/dashboard/dashboard-front/src/components/admin/AdministrationView.vue
+++ b/dashboard/dashboard-front/src/components/admin/AdministrationView.vue
@@ -155,7 +155,7 @@ function onPluginUploaded(info: any) {
 
             <q-field outlined label="Grafana dashboards" stack-label class="q-mt-md">
                 <template v-slot:control>
-                    <a :href="envInfo.grafana_url" target="_blank" class="x-overflow-any">
+                    <a :href="envInfo.grafana_url || ''" target="_blank" class="x-overflow-any">
                         {{ envInfo.grafana_url }}
                     </a>
                 </template>

--- a/dashboard/dashboard-front/src/components/jobs/JobDetails.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobDetails.vue
@@ -141,7 +141,7 @@ function reprovisionJob(job: JobData) {
         </q-btn-dropdown>
 
         <DeleteJobButton :jobName="job?.name || ''" :jobVersion="job?.version || ''"
-            @deleteJob="emit('refreshJobs', null)" />
+            @jobDeleted="emit('refreshJobs', null)" />
     </q-btn-group>
     </div>
 

--- a/dashboard/dashboard-front/src/components/jobs/JobDetails.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobDetails.vue
@@ -2,7 +2,7 @@
 import { type Ref, computed, ref } from 'vue'
 import { openURL } from 'quasar'
 import * as yaml from 'js-yaml'
-import { mdiTextBoxOutline } from '@quasar/extras/mdi-v7'
+import { mdiDotsVertical, mdiTextBoxOutline } from '@quasar/extras/mdi-v7'
 import { progressService } from '@/services/ProgressService'
 import { apiClient } from '@/services/ApiClient'
 import { type JobData } from '@/utils/api-schema'
@@ -11,6 +11,7 @@ import { timestampToLocalTime, timestampPrettyAgo } from '@/utils/time'
 import JobStatus from '@/components/jobs/JobStatus.vue'
 import DeleteJobButton from '@/components/jobs/DeleteJobButton.vue'
 import LogsView from '@/components/jobs/LogsView.vue'
+import { getJobGraphanaUrl } from '@/utils/jobs'
 
 const emit = defineEmits(['refreshJobs'])
 const props = defineProps(['currentJob'])
@@ -100,6 +101,10 @@ function reprovisionJob(job: JobData) {
         },
     })
 }
+
+function openJobGrafanaDashboard(job: JobData) {
+    openURL(getJobGraphanaUrl(job))
+}
 </script>
 
 <template>
@@ -142,6 +147,16 @@ function reprovisionJob(job: JobData) {
 
         <DeleteJobButton :jobName="job?.name || ''" :jobVersion="job?.version || ''"
             @jobDeleted="emit('refreshJobs', null)" />
+
+        <q-btn-dropdown push color="white" label="" :dropdown-icon="mdiDotsVertical" text-color="black" no-icon-animation>
+            <q-list>
+                <q-item clickable v-close-popup @click="openJobGrafanaDashboard(job)">
+                    <q-item-section>
+                        <q-item-label>Open Grafana Dashboard <q-icon name="open_in_new" /></q-item-label>
+                    </q-item-section>
+                </q-item>
+            </q-list>
+        </q-btn-dropdown>
     </q-btn-group>
     </div>
 

--- a/dashboard/dashboard-front/src/components/jobs/JobStatus.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobStatus.vue
@@ -7,12 +7,13 @@ const props = defineProps({
 })
 const status: Ref<string> = computed(() => props.status || "")
 const color: Ref<string> = computed(() => {
-    if (status.value == "running") {
-        return "green"
-    } else if (status.value == "error") {
-        return "red"
-    } else {
-        return "orange"
+    switch (status.value) {
+        case "running": 
+            return "green"
+        case "error": 
+            return "red"
+        default: 
+            return "orange"
     }
 })
 </script>

--- a/dashboard/dashboard-front/src/components/jobs/JobStatus.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobStatus.vue
@@ -1,12 +1,29 @@
 <script setup lang="ts">
 import { type Ref, computed } from 'vue'
 
-const props = defineProps(['status'])
-const status: Ref<string | null> = computed(() => props.status)
+const props = defineProps({
+    status: { type: String, required: false },
+    short: { type: Boolean, required: false, default: false },
+})
+const status: Ref<string> = computed(() => props.status || "")
+const color: Ref<string> = computed(() => {
+    if (status.value == "running") {
+        return "green"
+    } else if (status.value == "error") {
+        return "red"
+    } else {
+        return "orange"
+    }
+})
 </script>
 
 <template>
-    <q-badge v-if="status == 'running'" color="green" text-color="white" label="RUNNING" />
-    <q-badge v-else-if="status == 'error'" color="red" text-color="white" label="ERROR" />
-    <q-badge v-else color="orange" text-color="white" :label="status" />
+    <template v-if="short">
+        <q-badge rounded :color="color">
+            <q-tooltip>{{status.toUpperCase()}}</q-tooltip>
+        </q-badge>
+    </template>
+    <template v-else>
+        <q-badge :color="color" text-color="white" :label="status.toUpperCase()" />
+    </template>
 </template>

--- a/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
@@ -65,6 +65,7 @@ function populateJobsTree() {
                 label: familyName,
                 key: `job-family:${familyName}`,
                 type: 'job-family',
+                childrenCount: jobs.length,
                 children: jobs.map(job => ({
                     label: `v${job.version}`,
                     key: `job:${job.name}-${job.version}`,
@@ -111,6 +112,11 @@ function collapseAll() {
     jobsQTreeRef.value?.collapseAll()
 }
 
+function updatedJobOrder() {
+    localStorage.setItem('jobs.order', JSON.stringify(jobOrder.value))
+    populateJobsTree()
+}
+
 watch(jobsData, () => {
     populateJobsTree()
 })
@@ -122,13 +128,24 @@ watch(jobsTree, () => {
 })
 
 onMounted(() => {
+    const storedOrder = localStorage.getItem('jobs.order')
+    if (storedOrder) {
+        try {
+            jobOrder.value = JSON.parse(storedOrder) as JobOrder
+        } catch(e) {
+            console.error(e)
+        }
+    }
+
     fetchJobs()
 })
 </script>
 <template>
     <q-card>
         <q-card-section class="q-pb-none">
-            <div class="text-h6">Jobs ({{jobsCount}})</div>
+            <div class="text-h6">Jobs
+                <q-badge outline color="grey">{{jobsCount}}</q-badge>
+            </div>
         </q-card-section>
         
         <q-card-section>
@@ -154,19 +171,19 @@ onMounted(() => {
                         <q-btn-dropdown rounded flat color="grey-7" icon="sort" dropdown-icon="none">
                             <q-list>
                                 <q-item>
-                                    <q-radio v-model="jobOrder" :val="JobOrder.ByName" @click="populateJobsTree()" v-close-popup
+                                    <q-radio v-model="jobOrder" :val="JobOrder.ByName" @click="updatedJobOrder()" v-close-popup
                                         label="Sort by name"/>
                                 </q-item>
                                 <q-item>
-                                    <q-radio v-model="jobOrder" :val="JobOrder.ByLatestFamily" @click="populateJobsTree()" v-close-popup
+                                    <q-radio v-model="jobOrder" :val="JobOrder.ByLatestFamily" @click="updatedJobOrder()" v-close-popup
                                         label="Sort by latest family"/>
                                 </q-item>
                                 <q-item>
-                                    <q-radio v-model="jobOrder" :val="JobOrder.ByLatestJob" @click="populateJobsTree()" v-close-popup
+                                    <q-radio v-model="jobOrder" :val="JobOrder.ByLatestJob" @click="updatedJobOrder()" v-close-popup
                                         label="Sort by latest job"/>
                                 </q-item>
                                 <q-item>
-                                    <q-radio v-model="jobOrder" :val="JobOrder.ByStatus" @click="populateJobsTree()" v-close-popup
+                                    <q-radio v-model="jobOrder" :val="JobOrder.ByStatus" @click="updatedJobOrder()" v-close-popup
                                         label="Sort by status"/>
                                 </q-item>
                             </q-list>
@@ -190,6 +207,11 @@ onMounted(() => {
                                         {{ prop.node.label }}
                                         <JobStatus :status="getJobByKey(prop.node.key)?.status" short />
                                     </div>
+                                </template>
+                                <template v-else-if="prop.node.type == 'job-family'">
+                                    {{ prop.node.label }}
+                                    &nbsp;
+                                    <q-badge outline color="grey">{{prop.node.childrenCount}}</q-badge>
                                 </template>
                                 <template v-else>
                                     {{ prop.node.label }}

--- a/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
@@ -15,7 +15,7 @@ enum JobOrder {
 
 const jobsData: Ref<JobData[]> = ref([])
 const jobsQTreeRef: Ref<QTree | null> = ref(null)
-const splitterModel: Ref<number> = ref(30)
+const splitterModel: Ref<number> = ref(35)
 const treeFilter: Ref<string> = ref('')
 const jobsByKey: Ref<Map<string, JobData>> = ref(new Map())
 const jobsTree: Ref<any[]> = ref([])
@@ -185,7 +185,7 @@ onMounted(() => {
             <q-splitter v-model="splitterModel">
                 <template v-slot:before>
 
-                    <div class="q-mr-sm">
+                    <div class="q-mr-sm" style="overflow-x: auto;">
                         <q-input filled v-model="treeFilter" label="Filter">
                             <template v-if="treeFilter" v-slot:append>
                                 <q-icon name="cancel" @click.stop.prevent="treeFilter = ''" class="cursor-pointer" />
@@ -235,7 +235,7 @@ onMounted(() => {
                             >
                             <template v-slot:default-header="prop">
                                 <template v-if="prop.node.type == 'job'">
-                                    <div>
+                                    <div class="text-no-wrap">
                                         {{ prop.node.label }}
                                         <JobStatus :status="getJobByKey(prop.node.key)?.status" />
                                     </div>

--- a/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
@@ -172,7 +172,7 @@ onMounted(() => {
 
                         <span>
                         <q-tooltip anchor="top middle">Sort by</q-tooltip>
-                        <q-btn-dropdown rounded flat color="grey-7" icon="sort" dropdown-icon="none">
+                        <q-btn-dropdown rounded flat color="grey-7" dropdown-icon="sort" no-icon-animation>
                             <q-list>
                                 <q-item>
                                     <q-radio v-model="jobOrder" :val="JobOrder.ByName" @click="updatedJobOrder()" v-close-popup

--- a/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
@@ -75,6 +75,10 @@ function populateJobsTree() {
         }
     }
     jobsTree.value = leafs
+
+    if (selectedNodeKey.value && !getJobByKey(selectedNodeKey.value)) { // current job has been deleted
+        currentJob.value = null
+    }
 }
 
 function selectJobNode(key: string | null) {

--- a/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
@@ -15,7 +15,7 @@ enum JobOrder {
 
 const jobsData: Ref<JobData[]> = ref([])
 const jobsQTreeRef: Ref<QTree | null> = ref(null)
-const splitterModel: Ref<number> = ref(35)
+const splitterModel: Ref<number> = ref(25)
 const treeFilter: Ref<string> = ref('')
 const jobsByKey: Ref<Map<string, JobData>> = ref(new Map())
 const jobsTree: Ref<any[]> = ref([])
@@ -81,7 +81,7 @@ function populateJobsData() {
                 key: `job-family:${familyName}`,
                 type: 'job-family',
                 children: jobs.map(job => ({
-                    label: `${job.name} v${job.version}`,
+                    label: `v${job.version}`,
                     key: `job:${job.name}-${job.version}`,
                     type: 'job',
                 }))

--- a/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobsListView.vue
@@ -237,7 +237,7 @@ onMounted(() => {
                                 <template v-if="prop.node.type == 'job'">
                                     <div class="text-no-wrap">
                                         {{ prop.node.label }}
-                                        <JobStatus :status="getJobByKey(prop.node.key)?.status" />
+                                        <JobStatus :status="getJobByKey(prop.node.key)?.status" short />
                                     </div>
                                 </template>
                                 <template v-else>

--- a/dashboard/dashboard-front/src/components/jobs/graph/GraphArea.vue
+++ b/dashboard/dashboard-front/src/components/jobs/graph/GraphArea.vue
@@ -14,6 +14,7 @@ const focusedNodes: Ref<string[]> = ref([])
 const legendTitle: Ref<string> = ref('')
 const legendBody: Ref<string> = ref('')
 const physics: Ref<boolean> = ref(true)
+const loading = ref(true)
 
 interface JobGraph {
     nodes: JobGraphNode[]
@@ -33,12 +34,15 @@ interface JobGraphEdge {
 }
 
 function fetchGraph() {
+    loading.value = true
     apiClient.get(`/api/v1/job/graph`).then(response => {
         const data: JobGraph = response.data
         graphData.nodes = data.nodes
         graphData.edges = data.edges
     }).catch(err => {
         toastService.showErrorDetails(`Failed to fetch a jobs graph`, err)
+    }).finally(() => {
+        loading.value = false
     })
 }
 
@@ -177,4 +181,7 @@ function colorOfNodeByType(nodeType: string) {
             <div v-html="legendBody"></div>
         </q-card-section>
     </q-card>
+    <q-inner-loading :showing="loading">
+        <q-spinner-gears size="50px" color="primary" />
+    </q-inner-loading>
 </template>

--- a/dashboard/dashboard-front/src/components/jobs/portfolio/PortfolioTable.vue
+++ b/dashboard/dashboard-front/src/components/jobs/portfolio/PortfolioTable.vue
@@ -150,7 +150,7 @@ onUpdated(() => {
                 <td>{{ formatTimestampIso8601(job.create_time) }}</td>
                 <td>{{ job.infrastructure_target }}</td>
                 <td>
-                    <DeleteJobButton :jobName="job.name" :jobVersion="job.version" @deleteJob="fetchJobs()" />
+                    <DeleteJobButton :jobName="job.name" :jobVersion="job.version" @jobDeleted="fetchJobs()" />
                 </td>
             </tr>
 

--- a/dashboard/dashboard-front/src/services/EnvironmentInfo.ts
+++ b/dashboard/dashboard-front/src/services/EnvironmentInfo.ts
@@ -9,6 +9,7 @@ export const envInfo: EnvironmentInfo = reactive({
     docker_tag: null,
     lifecycle_url: null,
     external_pub_url: null,
+    grafana_url: null,
     site_name: null,
 })
 
@@ -19,6 +20,7 @@ export interface EnvironmentInfo {
     docker_tag: string | null
     lifecycle_url: string | null
     external_pub_url: string | null
+    grafana_url: string | null
     site_name: string | null
 }
 
@@ -35,6 +37,7 @@ export function loadEnvironmentInfo() {
             envInfo.lifecycle_url = data.lifecycle_url
             envInfo.external_pub_url = data.external_pub_url
             envInfo.site_name = data.site_name
+            envInfo.grafana_url = data.grafana_url
 
             if (envInfo.site_name) {
                 document.title = `[${envInfo.site_name}] Racetrack Dashboard`

--- a/dashboard/dashboard-front/src/utils/jobs.ts
+++ b/dashboard/dashboard-front/src/utils/jobs.ts
@@ -1,0 +1,74 @@
+import type { JobData } from "./api-schema"
+
+export enum JobOrder {
+    ByLatestFamily,
+    ByLatestJob,
+    ByName,
+    ByStatus,
+}
+
+export function sortedJobs(jobs: JobData[], order: JobOrder) {
+    const sortedJobs: JobData[] = [...jobs]
+    if (order === JobOrder.ByLatestFamily || order === JobOrder.ByLatestJob) {
+        sortedJobs.sort((a, b) => {
+            return b.update_time - a.update_time
+        })
+    } else if (order === JobOrder.ByName) {
+        sortedJobs.sort((a, b) => {
+            return compareJobNames(a, b)
+                || compareVersions(b.version, a.version)
+        })
+    } else if (order === JobOrder.ByStatus) {
+        sortedJobs.sort((a, b) => {
+            return statusImportance(a.status) - statusImportance(b.status)
+                || compareJobNames(a, b)
+                || compareVersions(b.version, a.version)
+        })
+    }
+    return sortedJobs
+}
+
+function compareVersions(a: string, b: string): number {
+    const regexp = /^(\d+)\.(\d+)\.(\d+)(.*)$/g
+    const matchesA = regexp.exec(a)
+    regexp.lastIndex = 0
+    const matchesB = regexp.exec(b)
+    if (!matchesA || !matchesB) {
+        return 0
+    }
+    return parseInt(matchesA[1]) - parseInt(matchesB[1])
+        || parseInt(matchesA[2]) - parseInt(matchesB[2])
+        || parseInt(matchesA[3]) - parseInt(matchesB[3])
+        || matchesA[4].localeCompare(matchesB[4])
+}
+
+function compareJobNames(a: JobData, b: JobData): number {
+    return a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+}
+
+function statusImportance(status: string): number {
+    switch (status) {
+        case "running":
+            return 0
+        case "error":
+            return -2
+        default:
+            return -1
+    }
+}
+
+export function filterJobByKeyword(job: JobData, keyword: string): boolean {
+    if (job.name.toLowerCase().includes(keyword))
+        return true
+    if (job.version.toLowerCase().includes(keyword))
+        return true
+    if (job.deployed_by?.toLowerCase().includes(keyword))
+        return true
+    if (job.status.toLowerCase().includes(keyword))
+        return true
+    if (job.job_type_version?.toLowerCase().includes(keyword))
+        return true
+    if (job.manifest?.['owner_email']?.toLowerCase().includes(keyword))
+        return true
+    return false
+}

--- a/dashboard/dashboard-front/src/utils/jobs.ts
+++ b/dashboard/dashboard-front/src/utils/jobs.ts
@@ -1,4 +1,5 @@
 import type { JobData } from "./api-schema"
+import { envInfo } from '@/services/EnvironmentInfo'
 
 export enum JobOrder {
     ByLatestFamily,
@@ -71,4 +72,9 @@ export function filterJobByKeyword(job: JobData, keyword: string): boolean {
     if (job.manifest?.['owner_email']?.toLowerCase().includes(keyword))
         return true
     return false
+}
+
+export function getJobGraphanaUrl(job: JobData): string {
+    // "Jobs" dashboard filtered by job name and version
+    return `${envInfo.grafana_url}/d/KZoFMs_nz/jobs?orgId=1&var-job_name=${job.name}&var-job_version=${job.version}`
 }

--- a/dashboard/dashboard/api/api.py
+++ b/dashboard/dashboard/api/api.py
@@ -7,7 +7,7 @@ from starlette.datastructures import MutableHeaders
 
 from racetrack_client.log.logs import get_logger
 from racetrack_client.utils.url import trim_url
-from racetrack_commons.urls import get_external_lifecycle_url, get_external_pub_url
+from racetrack_commons.urls import get_external_grafana_url, get_external_lifecycle_url, get_external_pub_url
 from dashboard.api.docs import setup_docs_endpoints
 
 logger = get_logger(__name__)
@@ -26,6 +26,7 @@ def setup_api_endpoints(app: FastAPI):
             'docker_tag': os.environ.get('DOCKER_TAG', ''),
             'lifecycle_url': get_external_lifecycle_url(),
             'external_pub_url': get_external_pub_url(),
+            'grafana_url': get_external_grafana_url(),
             'site_name': os.environ.get('SITE_NAME', ''),
         }
     

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,7 @@ services:
       LIFECYCLE_URL: 'http://lifecycle:7102/lifecycle'
       EXTERNAL_LIFECYCLE_URL: 'http://localhost:7102/lifecycle'
       EXTERNAL_PUB_URL: 'http://localhost:7105/pub'
+      EXTERNAL_GRAFANA_URL: 'http://localhost:3100'
       AUTH_REQUIRED: 'true'
       SITE_NAME: ''
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,17 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Dashboard links to job-related Grafana dashobards.
+  [issue #206](https://github.com/TheRacetrack/racetrack/issues/206)
 
 ### Changed
 - Minor UI improvements and styling for Dashboard, including:
-  - Shwoing spinner during loading the graph tab
-  - Narrower navbar
-  - Status indicator (green/red/yellow) on a jobs tree
-  - Panel takes up the whole space available - no white bars on the sides
   - Sorting jobs by status (starting from faulty ones)
   - Jobs ordering is persisted in local storage
-  - Number of jobs near family
-  - Refreshing tree of jobs after deleting one
+  - Spinner indicators during loading the data
+  - Status indicator (green/red/yellow) and number of jobs on a jobs tree
+  - Panel takes up the whole space available - no white bars on the sides
+
+### Fixed
+- Tree of jobs is refreshed after deleting a job.
+  [issue #211](https://github.com/TheRacetrack/racetrack/issues/211)
 
 ## [2.13.0] - 2023-05-10
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Dashboard links to job-related Grafana dashobards.
+
+### Changed
+- Minor UI improvements and styling for Dashboard, including:
+  - Shwoing spinner during loading the graph tab
+  - Narrower navbar
+  - Status indicator (green/red/yellow) on a jobs tree
+  - Panel takes up the whole space available - no white bars on the sides
+  - Sorting jobs by status (starting from faulty ones)
+  - Jobs ordering is persisted in local storage
+  - Number of jobs near family
+  - Refreshing tree of jobs after deleting one
 
 ## [2.13.0] - 2023-05-10
 ### Added

--- a/kustomize/kind/dashboard.yaml
+++ b/kustomize/kind/dashboard.yaml
@@ -37,6 +37,8 @@ spec:
               value: 'http://localhost:7002/lifecycle'
             - name: EXTERNAL_PUB_URL
               value: 'http://localhost:7005/pub'
+            - name: EXTERNAL_GRAFANA_URL
+              value: 'http://localhost:3000'
             - name: DJANGO_DEBUG
               value: 'true'
             - name: AUTH_REQUIRED

--- a/racetrack_commons/racetrack_commons/urls.py
+++ b/racetrack_commons/racetrack_commons/urls.py
@@ -24,3 +24,11 @@ def get_external_lifecycle_url() -> str:
     if not external_lifecycle_url:
         return 'neither CLUSTER_FQDN nor EXTERNAL_LIFECYCLE_URL has been set'
     return f'{external_lifecycle_url}'
+
+
+def get_external_grafana_url() -> str:
+    cluster_domain = os.environ.get('CLUSTER_FQDN')
+    if cluster_domain:
+        racetrack_subdomain = os.environ.get('RACETRACK_SUBDOMAIN', 'racetrack')
+        return f'https://{racetrack_subdomain}.{cluster_domain}/grafana'
+    return os.environ.get('EXTERNAL_GRAFANA_URL', 'http://localhost:3000')


### PR DESCRIPTION
Closes https://github.com/TheRacetrack/racetrack/issues/211

Closes https://github.com/TheRacetrack/racetrack/issues/206

Minor UI improvements for a Dashboard:
- Annotate login form fields correctly so that browsers can prompt you to remember the password.
- Add horizontal scroll to jobs tree in case of a long job name
- Add inner loading to graph view
- narrower navbar
- Show status indicator (green/red/yellow) instead of full status badge on a jobs tree
- "Jobs" panel takes up the whole space available - no white bars on the sides
- job name is not repeated in the tree leafs
- Add sorting jobs by status - first faulty jobs
- Store current jobs ordering in local storage
- show number of jobs near family
- Refresh list of jobs after deleting one
- Link to job-related Grafana dashobard