### PR TITLE
Show more details in case of racetrack-client HTTP error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Panel takes up the whole space available - no white bars on the sides
   - Jobs tree has its own scrollbar
   - "10 seconds ago" labels are refreshed over time.
+- racetrack-client shows more details in case of an HTTP error.
+  [issue #245](https://github.com/TheRacetrack/racetrack/issues/245)
 
 ### Fixed
 - Tree of jobs is refreshed after deleting a job.

--- a/racetrack_client/racetrack_client/utils/request.py
+++ b/racetrack_client/racetrack_client/utils/request.py
@@ -32,11 +32,13 @@ class Response:
     def __init__(
         self,
         url: str,
+        method: str,
         status_code: int,
         content: bytes,
         headers: Message,
     ):
         self._url: str = url
+        self._method: str = method.upper()
         self._status_code: int = status_code
         self._content: bytes = content
         self._headers: Message = headers
@@ -80,11 +82,19 @@ class Response:
         return self._url
     
     @property
+    def method(self) -> str:
+        return self._method
+    
+    @property
     def headers(self) -> Message:
         return self._headers
     
     def header(self, name: str) -> Optional[str]:
         return self._headers[name]
+
+    @property
+    def error_details(self) -> str:
+        return f'{self.status_code} {self.status_reason} for url: {self.method} {self.url}'
 
 
 class Requests:
@@ -217,6 +227,7 @@ class Requests:
             http_response: HTTPResponse = request.urlopen(req, **kwargs)
             return Response(
                 url=url,
+                method=method,
                 status_code=http_response.status,
                 content=http_response.read(),
                 headers=http_response.headers,
@@ -224,6 +235,7 @@ class Requests:
         except HTTPError as e:
             return Response(
                 url=url,
+                method=method,
                 status_code=e.code,
                 content=e.read(),
                 headers=e.headers,
@@ -278,7 +290,7 @@ def parse_response(response: Response, error_context: str) -> Optional[Union[Dic
 
         if result is not None and isinstance(result, dict) and 'error' in result:
             raise ContextError(response.status_reason, RuntimeError(result.get("error")))
-        raise ResponseError(f'{response.status_code} {response.status_reason} for url: {response.url}', response.status_code)
+        raise ResponseError(response.error_details, response.status_code)
     except Exception as e:
         raise ResponseError(error_context, response.status_code) from e
 
@@ -286,7 +298,8 @@ def parse_response(response: Response, error_context: str) -> Optional[Union[Dic
 def parse_response_object(response: Response, error_context: str) -> Dict:
     try:
         if 'application/json' not in response.headers['content-type']:
-            raise RuntimeError(f'expected JSON response, got "{response.headers["content-type"]}" for url: {response.url}')
+            raise RuntimeError(f'expected JSON response, got "{response.headers["content-type"]}", '
+                               f'{response.error_details}')
 
         result = response.json()
 
@@ -296,7 +309,7 @@ def parse_response_object(response: Response, error_context: str) -> Dict:
 
         if result is not None and isinstance(result, dict) and 'error' in result:
             raise ContextError(response.status_reason, RuntimeError(result.get("error")))
-        raise ResponseError(f'{response.status_code} {response.status_reason} for url: {response.url}', response.status_code)
+        raise ResponseError(response.error_details, response.status_code)
     except Exception as e:
         raise ResponseError(error_context, response.status_code) from e
 
@@ -304,7 +317,8 @@ def parse_response_object(response: Response, error_context: str) -> Dict:
 def parse_response_list(response: Response, error_context: str) -> List:
     try:
         if 'application/json' not in response.headers['content-type']:
-            raise RuntimeError(f'expected JSON response, got "{response.headers["content-type"]}" for url: {response.url}')
+            raise RuntimeError(f'expected JSON response, got "{response.headers["content-type"]}", '
+                               f'{response.error_details}')
 
         result = response.json()
 
@@ -314,6 +328,6 @@ def parse_response_list(response: Response, error_context: str) -> List:
 
         if result is not None and isinstance(result, dict) and 'error' in result:
             raise ContextError(response.status_reason, RuntimeError(result.get("error")))
-        raise ResponseError(f'{response.status_code} {response.status_reason} for url: {response.url}', response.status_code)
+        raise ResponseError(response.error_details, response.status_code)
     except Exception as e:
         raise ResponseError(error_context, response.status_code) from e

--- a/racetrack_client/tests/utils/test_parse_response.py
+++ b/racetrack_client/tests/utils/test_parse_response.py
@@ -83,7 +83,7 @@ def test_response_failed():
     with pytest.raises(Exception) as excinfo:
         parse_response(response, 'deploying error')
     assert (
-        str(excinfo.value) == 'deploying error: 404 Not Found for url: http://localhost/blahblah'
+        str(excinfo.value) == 'deploying error: 404 Not Found for url: GET http://localhost/blahblah'
     )
 
 

--- a/racetrack_client/tests/utils/test_request.py
+++ b/racetrack_client/tests/utils/test_request.py
@@ -25,6 +25,7 @@ def test_request_get_json():
     assert response.text == '{"result": "ok"}'
     assert response.json() == {'result': 'ok'}
     assert response.url == _url
+    assert response.method == 'GET'
     assert response.headers['content-type'] == 'application/json'
     assert response.headers['Content-Type'] == 'application/json'
     assert response.header('content-type') == 'application/json'


### PR DESCRIPTION
When HTTP error occurs due to Cloudflare's proxy, it's hard to debug when all we got is just:
```
expected JSON response, got "text/html; charset=UTF-8" for url
```
Let's print more details in such cases:
- status code
- method