### PR TITLE
Keep manifest up-to-date with running job

### DIFF
--- a/dashboard/dashboard-front/src/components/jobs/JobDetails.vue
+++ b/dashboard/dashboard-front/src/components/jobs/JobDetails.vue
@@ -27,8 +27,10 @@ const loadingLogs: Ref<boolean> = ref(false)
 const manifestDialogRef: Ref<typeof ManifestEditDialog | null> = ref(null)
 
 const manifestYaml: Ref<string> = computed(() => {
-    if (!job.value?.manifest)
+    if (!job.value?.manifest) {
+        console.log('Empty job manifest')
         return ''
+    }
     return yaml.dump(removeNulls(job.value?.manifest)) || ''
 })
 

--- a/dashboard/dashboard-front/src/components/jobs/ManifestEditDialog.vue
+++ b/dashboard/dashboard-front/src/components/jobs/ManifestEditDialog.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import type { JobData } from '@/utils/api-schema'
 import { ref, type Ref } from 'vue'
-import * as yaml from 'js-yaml'
 import { progressService } from '@/services/ProgressService'
-import { removeNulls } from '@/utils/string'
 import { apiClient } from '@/services/ApiClient'
 
 const dialogOpen = ref(false)
@@ -11,9 +9,9 @@ const loading = ref(false)
 const job: Ref<JobData | null> = ref(null)
 const manifestYaml: Ref<string> = ref('')
 
-function openDialog(jobData: JobData) {
+function openDialog(jobData: JobData, yamlText: string) {
     job.value = jobData
-    manifestYaml.value = yaml.dump(removeNulls(jobData.manifest)) || ''
+    manifestYaml.value = yamlText
     dialogOpen.value = true
 }
 

--- a/dashboard/dashboard-front/src/services/ProgressService.ts
+++ b/dashboard/dashboard-front/src/services/ProgressService.ts
@@ -15,7 +15,7 @@ interface ConfirmWithLoadingOptions {
 
 interface RunLoadingOptions {
     task: Promise<any>
-    loadingState: Ref<boolean>
+    loadingState?: Ref<boolean>
     progressMsg: string
     successMsg?: string
     errorMsg: string
@@ -67,12 +67,14 @@ export class ProgressService {
         {task, loadingState, progressMsg, successMsg, errorMsg, onSuccess, onFinalize}: RunLoadingOptions
     ) {
         toastService.loading(progressMsg)
-        loadingState.value = true
+        if (loadingState != null)
+            loadingState.value = true
         this.startLoadingProgress()
 
         task.finally(() => {
                 toastService.dismissLoading()
-                loadingState.value = false
+                if (loadingState != null)
+                    loadingState.value = false
                 this.stopLoadingProgress()
                 onFinalize?.()
                 


### PR DESCRIPTION
This runs full redeployment right after editing the manifest of a job.