### PR TITLE
Job's home page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Job types can read the manifest file from the job's directory.
+  It might be useful to configure the home page of a job
+  ([see example](https://github.com/TheRacetrack/plugin-python-job-type/blob/5625a2b892704da3a935df0049c5b9a0fc49870d/docs/job_python3.md#home-page)).
 
 ## [2.17.0] - 2023-07-17
 ### Added

--- a/image_builder/image_builder/build.py
+++ b/image_builder/image_builder/build.py
@@ -63,6 +63,8 @@ def build_job_image(
 
             workspace, repo_dir, git_version = prepare_workspace(workspaces_path, manifest, git_credentials, build_context, deployment_id)
 
+            (workspace / 'job.yaml').write_text(manifest.origin_yaml_)
+
         build_env_vars = merge_env_vars(manifest.build_env, secret_build_env)
 
         update_deployment_phase(config, deployment_id, 'building image')


### PR DESCRIPTION
This feature is mostly provided by the job type plugin: https://github.com/TheRacetrack/plugin-python-job-type/pull/23.

The only thing that had to be made was to share the manifest file with the job itself so it can read it.