### PR TITLE
Replace old version when uploading a plugin

### DIFF
--- a/dashboard/dashboard-front/package-lock.json
+++ b/dashboard/dashboard-front/package-lock.json
@@ -2062,9 +2062,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -4006,9 +4006,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "shebang-command": {

--- a/dashboard/dashboard-front/src/components/admin/AdministrationView.vue
+++ b/dashboard/dashboard-front/src/components/admin/AdministrationView.vue
@@ -8,6 +8,7 @@ import { versionFull } from '@/services/EnvironmentInfo'
 import { progressService } from '@/services/ProgressService'
 import { authToken } from '@/services/UserDataStore'
 import { extractErrorDetails } from "@/utils/error"
+import { rememberInLocalStorage } from '@/utils/storage'
 
 const pluginDataRef: Ref<PluginData> = ref({
     plugins: [],
@@ -18,6 +19,7 @@ const pluginDataRef: Ref<PluginData> = ref({
 const lifecycleAdminUrl = computed(() => `${envInfo.lifecycle_url}/admin`)
 const jobTypeVersionsTreeRef: Ref<QTree | null> = ref(null)
 const infrastructureTargetsTreeRef: Ref<QTree | null> = ref(null)
+const replacePlugins: Ref<boolean> = ref(false)
 
 interface PluginManifest {
     name: string
@@ -94,6 +96,7 @@ function fetchPluginsData() {
 }
 
 onMounted(() => {
+    rememberInLocalStorage(replacePlugins, 'administration.replacePlugins')
     fetchPluginsData()
 })
 
@@ -245,8 +248,11 @@ function onPluginUploaded(info: any) {
         </q-card-section>
 
         <q-card-section>
+            <q-checkbox v-model="replacePlugins" label="Replace on upload">
+                <q-tooltip>Delete the existing versions of the same uploaded plugin</q-tooltip>
+            </q-checkbox>
             <q-uploader
-                url="/dashboard/api/v1/plugin/upload"
+                :url="`/dashboard/api/v1/plugin/upload?replace=${replacePlugins ? '1' : '0'}`"
                 label="Upload plugin"
                 :headers="[{name: authHeader, value: authToken}]"
                 field-name="file"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Job types can read the manifest file from the job's directory.
   It might be useful to configure the home page of a job
   ([see example](https://github.com/TheRacetrack/plugin-python-job-type/blob/5625a2b892704da3a935df0049c5b9a0fc49870d/docs/job_python3.md#home-page)).
+- Racetrack-client has new flag `--replace` available when uploading a plugin:
+  `racetrack plugin install <file.zip> --replace`.
+  It will delete the existing versions (with the same name) on uploading a new one.
+  Accordingly, there is a checkbox on the Dashboard's *Administration* tab for replacing a plugin on upload.
+  By default, uploading a new plugin doesn't replace the older versions.
+  ([#270](https://github.com/TheRacetrack/racetrack/issues/270))
 
 ### Changed
 - When a job is built from local files (with `--build-context=local`),

--- a/lifecycle/lifecycle/endpoints/plugin.py
+++ b/lifecycle/lifecycle/endpoints/plugin.py
@@ -39,13 +39,13 @@ def setup_plugin_endpoints(api: APIRouter, config: Config, plugin_engine: Plugin
         plugin_engine.upload_plugin(file.filename, file_bytes)
 
     @api.post('/plugin/upload/{filename}')
-    async def _upload_plugin_bytes(filename: str, request: Request) -> PluginManifest:
+    async def _upload_plugin_bytes(filename: str, request: Request, replace: int = 0) -> PluginManifest:
         """Upload plugin from ZIP file sending raw bytes in body"""
         check_staff_user(request)
         file_bytes: bytes = await request.body()
         loop = asyncio.get_running_loop()
         # Run synchronous function asynchronously without blocking an event loop, using default ThreadPoolExecutor
-        return await loop.run_in_executor(None, plugin_engine.upload_plugin, filename, file_bytes)
+        return await loop.run_in_executor(None, plugin_engine.upload_plugin, filename, file_bytes, bool(replace))
     
     @api.delete('/plugin/{plugin_name}/{plugin_version}')
     def _delete_plugin_by_version(plugin_name: str, plugin_version: str, request: Request):

--- a/lifecycle/lifecycle/endpoints/plugin.py
+++ b/lifecycle/lifecycle/endpoints/plugin.py
@@ -32,11 +32,11 @@ def setup_plugin_endpoints(api: APIRouter, config: Config, plugin_engine: Plugin
         return plugin_engine.plugin_manifests
 
     @api.post('/plugin/upload')
-    def _upload_plugin(file: UploadFile, request: Request):
+    def _upload_plugin(file: UploadFile, request: Request, replace: int = 0):
         """Upload plugin from ZIP file using multipart/form-data"""
         check_staff_user(request)
         file_bytes = file.file.read()
-        plugin_engine.upload_plugin(file.filename, file_bytes)
+        plugin_engine.upload_plugin(file.filename, file_bytes, bool(replace))
 
     @api.post('/plugin/upload/{filename}')
     async def _upload_plugin_bytes(filename: str, request: Request, replace: int = 0) -> PluginManifest:

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -218,9 +218,10 @@ cli.add_typer(cli_plugin, name="plugin")
 def _install_plugin(
     plugin_uri: str = typer.Argument(..., show_default=False, help='location of the plugin file: local file path, HTTP URL to a remote file or repository name'),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
+    replace: bool = typer.Option(False, '--replace', help='delete the existing versions of the same plugin'),
 ):
     """Install a plugin to a remote Racetrack server"""
-    install_plugin(plugin_uri, remote)
+    install_plugin(plugin_uri, remote, replace=replace)
 
 
 @cli_plugin.command('uninstall', no_args_is_help=True)

--- a/racetrack_client/racetrack_client/plugin/install.py
+++ b/racetrack_client/racetrack_client/plugin/install.py
@@ -21,8 +21,12 @@ def install_plugin(
     plugin_uri: str,
     lifecycle_url: Optional[str],
     client_config: Optional[ClientConfig] = None,
+    replace: bool = False,
 ):
-    """Install a plugin to a remote Racetrack server"""
+    """
+    Install a plugin to a remote Racetrack server
+    :param replace: whether to replace the older versions - delete the existing versions with the same name
+    """
     if client_config is None:
         client_config = load_client_config()
     lifecycle_url = resolve_lifecycle_url(client_config, lifecycle_url)
@@ -32,7 +36,7 @@ def install_plugin(
 
     logger.info(f'Uploading plugin {plugin_uri} to {lifecycle_url}')
     r = Requests.post(
-        f'{lifecycle_url}/api/v1/plugin/upload/{plugin_filename}',
+        f'{lifecycle_url}/api/v1/plugin/upload/{plugin_filename}?replace={int(replace)}',
         data=plugin_content,
         headers=get_auth_request_headers(user_auth),
     )

--- a/racetrack_commons/racetrack_commons/entities/plugin_client.py
+++ b/racetrack_commons/racetrack_commons/entities/plugin_client.py
@@ -27,8 +27,8 @@ class LifecyclePluginClient:
     def delete_plugin(self, plugin_name: str, plugin_version: str):
         self.lc_client.request('delete', f'/api/v1/plugin/{plugin_name}/{plugin_version}')
 
-    def upload_plugin(self, filename: str, file_bytes: bytes):
-        r = Requests.post(f'{self.lc_client.lifecycle_api_url}/api/v1/plugin/upload/{filename}',
+    def upload_plugin(self, filename: str, file_bytes: bytes, replace: bool = False):
+        r = Requests.post(f'{self.lc_client.lifecycle_api_url}/api/v1/plugin/upload/{filename}?replace={int(replace)}',
                           data=file_bytes,
                           headers=self.lc_client.get_auth_headers())
         parse_response(r, 'Lifecycle response')


### PR DESCRIPTION
- Racetrack-client has new flag `--replace` available when uploading a plugin:
  `racetrack plugin install <file.zip> --replace`.
  It will delete the existing versions (with the same name) on uploading a new one.
  Accordingly, there is a checkbox on the Dashboard's *Administration* tab for replacing a plugin on upload.
  By default, uploading a new plugin doesn't replace the older versions.

![Screenshot from 2023-07-27 09-17-46](https://github.com/TheRacetrack/racetrack/assets/45496492/f830bff9-2b87-4b3b-9401-8c0851abe1c0)

