### PR TITLE
Verify database name evaluation

### DIFF
--- a/postgres/wait-for-postgres.sh
+++ b/postgres/wait-for-postgres.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-until pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DB; do
+until pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER; do
     echo "Waiting for ${POSTGRES_HOST}:${POSTGRES_PORT}";
     sleep 1;
 done;


### PR DESCRIPTION
This is getting rid of silly connection attempt to `racetrack-{CLUSTER_NAME}`  database