### PR TITLE
Fix intermittent error when uploading a plugin

### DIFF
--- a/image_builder/image_builder/api.py
+++ b/image_builder/image_builder/api.py
@@ -15,7 +15,6 @@ from racetrack_client.utils.config import load_config
 from racetrack_commons.api.asgi.asgi_server import serve_asgi_app
 from racetrack_commons.api.asgi.fastapi import create_fastapi
 from racetrack_commons.api.metrics import setup_metrics_endpoint
-from racetrack_commons.deploy.job_type import list_available_job_types
 from racetrack_commons.plugin.engine import PluginEngine
 
 
@@ -140,8 +139,3 @@ def _setup_api_endpoints(api: APIRouter, config: Config, plugin_engine: PluginEn
             'logs': logs,
             'error': error,
         }
-
-    @api.get('/job_type/versions')
-    def _get_job_type_versions() -> List[str]:
-        """List available job type versions"""
-        return list_available_job_types(plugin_engine)

--- a/image_builder/image_builder/docker/builder.py
+++ b/image_builder/image_builder/docker/builder.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os
 from pathlib import Path
 import time

--- a/lifecycle/lifecycle/auth/cookie.py
+++ b/lifecycle/lifecycle/auth/cookie.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os
 from urllib.parse import quote
 

--- a/lifecycle/lifecycle/endpoints/plugin.py
+++ b/lifecycle/lifecycle/endpoints/plugin.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import asyncio
 import collections
 from typing import List, Optional, Any
@@ -6,7 +5,7 @@ from typing import List, Optional, Any
 from pydantic import BaseModel, Field
 from fastapi import APIRouter, UploadFile, Request
 
-from racetrack_client.utils.request import Requests, parse_response_list
+from lifecycle.server.cache import LifecycleCache
 from racetrack_client.plugin.plugin_manifest import PluginManifest
 from racetrack_commons.plugin.core import PluginCore
 from racetrack_commons.plugin.engine import PluginEngine
@@ -86,8 +85,7 @@ def setup_plugin_endpoints(api: APIRouter, config: Config, plugin_engine: Plugin
     @api.get('/plugin/job_type/versions')
     def _get_job_type_versions() -> list[str]:
         """List available job type versions"""
-        r = Requests.get(f'{config.image_builder_url}/api/v1/job_type/versions')
-        return parse_response_list(r, 'Image builder API error')
+        return sorted(LifecycleCache.job_types.keys())
 
     @api.get('/plugin/infrastructure_targets')
     def _get_infrastructure_targets() -> dict[str, PluginManifest]:
@@ -98,8 +96,7 @@ def setup_plugin_endpoints(api: APIRouter, config: Config, plugin_engine: Plugin
     def _get_plugin_trees() -> dict:
         infrastructure_targets: dict[str, PluginManifest] = list_infrastructure_names_with_origins(plugin_engine)
         plugins: list[PluginManifest] = plugin_engine.plugin_manifests
-        r = Requests.get(f'{config.image_builder_url}/api/v1/job_type/versions')
-        job_type_versions: list[str] = parse_response_list(r, 'Image builder API error')
+        job_type_versions: list[str] = sorted(LifecycleCache.job_types.keys())
 
         # Collect instances running on the same infrastructure
         _infrastructure_instances: dict[str, list[str]] = collections.defaultdict(list)

--- a/lifecycle/lifecycle/job/audit.py
+++ b/lifecycle/lifecycle/job/audit.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import json
 from typing import Dict, List, Optional
 

--- a/lifecycle/lifecycle/job/registry.py
+++ b/lifecycle/lifecycle/job/registry.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Iterable, Optional, List
 from collections import defaultdict
 from lifecycle.auth.authorize import list_permitted_families, list_permitted_jobs
@@ -9,11 +8,11 @@ from lifecycle.job import models_registry
 from lifecycle.job.audit import AuditLogger
 from lifecycle.job.dto_converter import job_model_to_dto, job_family_model_to_dto
 from lifecycle.monitor.monitors import list_cluster_jobs
+from lifecycle.server.cache import LifecycleCache
 from lifecycle.server.metrics import metric_jobs_count_by_status
 from racetrack_client.log.context_error import wrap_context
 from racetrack_client.log.logs import get_logger
 from racetrack_commons.auth.scope import AuthScope
-from racetrack_commons.deploy.job_type import list_available_job_types
 from racetrack_commons.deploy.resource import job_resource_name
 from racetrack_commons.entities.audit import AuditLogEventType
 from racetrack_commons.entities.dto import JobDto, JobFamilyDto, JobStatus
@@ -128,7 +127,7 @@ def sync_registry_jobs(config: Config, plugin_engine: PluginEngine):
     - if there are extra jobs found in the cluster, called "orphans", they are ignored, but the log warning is written.
     """
     with wrap_context('synchronizing job'):
-        available_job_types: set[str] = set(list_available_job_types(plugin_engine))
+        available_job_types: set[str] = set(LifecycleCache.job_types.keys())
         cluster_jobs_map: dict[str, JobDto] = _generate_job_map(list_cluster_jobs(config, plugin_engine))
         registry_jobs_map: dict[str, JobDto] = _generate_job_map(list_job_registry(config))
         job_status_count: dict[str, int] = defaultdict(int)

--- a/lifecycle/lifecycle/server/cache.py
+++ b/lifecycle/lifecycle/server/cache.py
@@ -1,3 +1,5 @@
+from racetrack_client.log.context_error import wrap_context
+from racetrack_commons.deploy.job_type import JobType, gather_job_types
 from racetrack_commons.plugin.core import PluginCore
 from racetrack_commons.plugin.engine import PluginEngine
 from lifecycle.infrastructure.model import InfrastructureTarget
@@ -5,10 +7,15 @@ from lifecycle.infrastructure.model import InfrastructureTarget
 
 class LifecycleCache:
     infrastructure_targets: dict[str, InfrastructureTarget] = {}
+    job_types: dict[str, JobType] = {}
 
     @classmethod
     def on_plugins_reload(cls, plugin_engine: PluginEngine):
-        cls.infrastructure_targets = {}
-        for result in plugin_engine.invoke_plugin_hook(PluginCore.infrastructure_targets):
-            if result:
-                cls.infrastructure_targets.update(result)
+        with wrap_context('gathering infrastructure targets'):
+            cls.infrastructure_targets = {}
+            for result in plugin_engine.invoke_plugin_hook(PluginCore.infrastructure_targets):
+                if result:
+                    cls.infrastructure_targets.update(result)
+
+        with wrap_context('gathering available job types'):
+            cls.job_types = gather_job_types(plugin_engine)

--- a/lifecycle/lifecycle/supervisor/metrics.py
+++ b/lifecycle/lifecycle/supervisor/metrics.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from pathlib import Path
 
 from lifecycle.config import Config

--- a/racetrack_commons/racetrack_commons/deploy/job_type.py
+++ b/racetrack_commons/racetrack_commons/deploy/job_type.py
@@ -36,7 +36,9 @@ def load_job_type(
     assert job_types, f'language {lang} is not supported here. No job type plugins are currently installed to Racetrack.'
     all_languages = sorted(job_types.keys())
     selected_version = match_job_type_version(lang, all_languages)
-    return job_types[selected_version]
+    job_type = job_types[selected_version]
+    _validate_job_type(job_type)
+    return job_type
 
 
 def match_job_type_version(lang: str, all_languages: list[str]) -> str:
@@ -93,22 +95,24 @@ def gather_job_types(
                 else:
                     raise RuntimeError(f'Invalid job type data. It should be list[tuple[Path, Path]], was {type(job_data)}')
 
-                _validate_dockerfile_paths(base_image_paths, template_paths, job_full_name)
-
                 name_parts = job_full_name.split(':')
                 assert len(name_parts) == 2, f'job type {job_full_name} should have the version defined (name:version)'
                 lang_name = name_parts[0]
                 lang_version = name_parts[1]
-                job_type_version = JobType(lang_name, lang_version, base_image_paths, template_paths)
+                job_type_version = JobType(
+                    lang_name=lang_name,
+                    version=lang_version,
+                    base_image_paths=base_image_paths,
+                    template_paths=template_paths,
+                )
                 job_types[job_full_name] = job_type_version
 
     return job_types
 
 
-def list_available_job_types(plugin_engine: PluginEngine) -> list[str]:
-    with wrap_context('gathering available job types'):
-        job_types = gather_job_types(plugin_engine)
-    return sorted(job_types.keys())
+def _validate_job_type(job_type: JobType):
+    job_full_name = f'{job_type.lang_name}:{job_type.version}'
+    _validate_dockerfile_paths(job_type.base_image_paths, job_type.template_paths, job_full_name)
 
 
 def _validate_dockerfile_paths(base_image_paths: list[Path], template_paths: list[Path], job_full_name: str):

--- a/racetrack_commons/racetrack_commons/deploy/job_type.py
+++ b/racetrack_commons/racetrack_commons/deploy/job_type.py
@@ -21,6 +21,10 @@ class JobType:
     base_image_paths: list[Path]  # paths to base Dockerfiles (for each container)
     template_paths: list[Path]  # paths to job template Dockerfiles (for each container)
 
+    @property
+    def full_name(self):
+        return f'{self.lang_name}:{self.version}'
+
 
 @backoff.on_exception(backoff.fibo, AssertionError, max_value=1, max_time=5, jitter=None, logger=None)
 def load_job_type(
@@ -111,8 +115,7 @@ def gather_job_types(
 
 
 def _validate_job_type(job_type: JobType):
-    job_full_name = f'{job_type.lang_name}:{job_type.version}'
-    _validate_dockerfile_paths(job_type.base_image_paths, job_type.template_paths, job_full_name)
+    _validate_dockerfile_paths(job_type.base_image_paths, job_type.template_paths, job_type.full_name)
 
 
 def _validate_dockerfile_paths(base_image_paths: list[Path], template_paths: list[Path], job_full_name: str):

--- a/racetrack_commons/racetrack_commons/plugin/engine.py
+++ b/racetrack_commons/racetrack_commons/plugin/engine.py
@@ -46,8 +46,8 @@ class PluginEngine:
                 logger.info(f'{len(self.plugins_data)} {plugin_plural} have been loaded in {duration:.2f}s: {plugins_list_str}')
             else:
                 logger.info(f'No plugins to load')
-        if self.on_reload is not None:
-            self.on_reload(self)
+            if self.on_reload is not None:
+                self.on_reload(self)
 
     def invoke_plugin_hook(self, function: Callable, *args, **kwargs) -> list[Any]:
         """


### PR DESCRIPTION
- Take available job types from lifecycle, not from image builder.
- Keep that in cache that call plugins engine only on-write