### PR TITLE
Override manifest values with command line params

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Manifest values can be overriden with key-value pairs coming from a command line.
+  Racetrack client has `--extra-vars KEY=VALUE` parameter (or `-e` in short)
+  that overwrites values found in YAML manifest.
+  `KEY` is the name of field and it can contain dots to refer to a nested field, for example `git.branch=master`.
+  `VALUE` can be any YAML or JSON object. 
+  Extra vars parameter can be used multiple times in one command.
+  Example: `racetrack deploy -e secret_runtime_env_file=.env.local`.
+  It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.
+  ([#340](https://github.com/TheRacetrack/racetrack/issues/340))
 
 ## [2.21.0] - 2023-10-16
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Manifest values can be overriden with key-value pairs coming from a command line.
   Racetrack client has `--extra-vars KEY=VALUE` parameter (or `-e` in short)
   that overwrites values found in YAML manifest.
-  `KEY` is the name of field and it can contain dots to refer to a nested field, for example `git.branch=master`.
-  `VALUE` can be any YAML or JSON object. 
-  Extra vars parameter can be used multiple times in one command.
-  Example: `racetrack deploy -e secret_runtime_env_file=.env.local`.
-  It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.
+
+  - `KEY` is the name of field and it can contain dots to refer to a nested field, for example `git.branch=master`.
+  - `VALUE` can be any YAML or JSON object.
+
+  Extra vars parameters can be used multiple times in one command.  
+  Example: `racetrack deploy -e secret_runtime_env_file=.env.local -e git.branch=$(git rev-parse --abbrev-ref HEAD)`  
+  It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.  
   Tip: Use `racetrack validate` command beforehand to make sure your final manifest is what you expected.
   ([#340](https://github.com/TheRacetrack/racetrack/issues/340))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Manifest values can be overriden with key-value pairs coming from a command line.
+  It doesn't modify actual file, but its one-time, in-memory version before submitting it.
   Racetrack client has `--extra-vars KEY=VALUE` parameter (or `-e` in short)
   that overwrites values found in YAML manifest.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Extra vars parameter can be used multiple times in one command.
   Example: `racetrack deploy -e secret_runtime_env_file=.env.local`.
   It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.
+  Tip: Use `racetrack validate` command beforehand to make sure your final manifest is what you expected.
   ([#340](https://github.com/TheRacetrack/racetrack/issues/340))
 
 ## [2.21.0] - 2023-10-16

--- a/racetrack_client/README.md
+++ b/racetrack_client/README.md
@@ -106,6 +106,7 @@ racetrack delete MuffinDestroyer
 
 ### Extra vars
 Manifest values can be overriden with key-value pairs coming from a command line.
+It doesn't modify actual file, but its one-time, in-memory version before submitting it.
 Racetrack client has `--extra-vars KEY=VALUE` parameter (or `-e` in short)
 that overwrites values found in YAML manifest.
 

--- a/racetrack_client/README.md
+++ b/racetrack_client/README.md
@@ -103,3 +103,21 @@ Delete your running job with:
 ```shell
 racetrack delete MuffinDestroyer
 ```
+
+### Extra vars
+Manifest values can be overriden with key-value pairs coming from a command line.
+Racetrack client has `--extra-vars KEY=VALUE` parameter (or `-e` in short)
+that overwrites values found in YAML manifest.
+
+- `KEY` is the name of field and it can contain dots to refer to a nested field, for example `git.branch=master`
+- `VALUE` can be any YAML or JSON object.
+
+Extra vars parameters can be used multiple times in one command.
+
+Example:
+```shell
+racetrack deploy -e secret_runtime_env_file=.env.local -e git.branch=$(git rev-parse --abbrev-ref HEAD)
+```
+
+It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.  
+Tip: Use `racetrack validate` command beforehand to make sure your final manifest is what you expected.

--- a/racetrack_client/racetrack_client/client/deploy.py
+++ b/racetrack_client/racetrack_client/client/deploy.py
@@ -50,6 +50,7 @@ def send_deploy_request(
     lifecycle_url: Optional[str] = None,
     force: bool = False,
     build_context_method: BuildContextMethod = BuildContextMethod.default,
+    extra_vars: Dict[str, str] = None,
 ):
     """
     Send request deploying a new Job to running Lifecycle instance
@@ -58,15 +59,16 @@ def send_deploy_request(
     :param lifecycle_url: Racetrack server's URL or alias name
     :param force: overwrite existing job without asking
     :param build_context_method: decides whether to build from local files or from git:
-        local - build an image from local build context, 
-        git - build from git repository, 
-        None - apply default strategy: 
+        local - build an image from local build context,
+        git - build from git repository,
+        None - apply default strategy:
             if working on local dev, local build context gets activated, otherwise git
+    :param extra_vars: key-value pairs overriding manifest values
     """
     if client_config is None:
         client_config = load_client_config()
-    manifest: Manifest = load_validated_manifest(workdir)
-    manifest_dict: Dict = load_merged_manifest_dict(get_manifest_path(workdir))
+    manifest: Manifest = load_validated_manifest(workdir, extra_vars)
+    manifest_dict: Dict = load_merged_manifest_dict(get_manifest_path(workdir), extra_vars)
     logger.debug(f'Manifest loaded: {manifest}')
 
     lifecycle_url = resolve_lifecycle_url(client_config, lifecycle_url)

--- a/racetrack_client/racetrack_client/client/run.py
+++ b/racetrack_client/racetrack_client/client/run.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional
 
 import backoff
 
+from racetrack_client.manifest import Manifest
 from racetrack_client.utils.shell import CommandError, shell
 from racetrack_client.utils.time import datetime_to_timestamp, now
 from racetrack_client.client.deploy import DEPLOYMENT_TIMEOUT_SECS, BuildContextMethod, DeploymentError, get_build_context, get_deploy_request_payload, get_git_credentials
@@ -26,10 +27,11 @@ def run_job_locally(
     lifecycle_url: str, 
     build_context_method: BuildContextMethod = BuildContextMethod.default,
     port: Optional[int] = None,
+    extra_vars: Dict[str, str] = None,
 ):
     client_config = load_client_config()
-    manifest = load_validated_manifest(workdir)
-    manifest_dict: Dict = load_merged_manifest_dict(get_manifest_path(workdir))
+    manifest: Manifest = load_validated_manifest(workdir, extra_vars)
+    manifest_dict: Dict = load_merged_manifest_dict(get_manifest_path(workdir), extra_vars)
 
     lifecycle_url = resolve_lifecycle_url(client_config, lifecycle_url)
     user_auth = get_user_auth(client_config, lifecycle_url)

--- a/racetrack_client/racetrack_client/manifest/merge.py
+++ b/racetrack_client/racetrack_client/manifest/merge.py
@@ -1,18 +1,20 @@
 from pathlib import Path
 from typing import Dict
 
+import yaml
+
 from racetrack_client.log.context_error import wrap_context
 from racetrack_client.manifest import Manifest
 from racetrack_client.manifest.load import load_manifest_dict_from_yaml, load_manifest_from_dict
 
 
-def load_merged_manifest(manifest_path: Path) -> Manifest:
+def load_merged_manifest(manifest_path: Path, extra_vars: Dict[str, str]) -> Manifest:
     """Load manifest from YAML file, resolve overlay layer, merging it with base manifest"""
-    manifest_dict = load_merged_manifest_dict(manifest_path)
+    manifest_dict = load_merged_manifest_dict(manifest_path, extra_vars)
     return load_manifest_from_dict(manifest_dict)
 
 
-def load_merged_manifest_dict(manifest_path: Path) -> Dict:
+def load_merged_manifest_dict(manifest_path: Path, extra_vars: Dict[str, str]) -> Dict:
     """
     Load dictionary representation of a manifest from YAML file, resolve overlay layer, merging it with base manifest
     """
@@ -31,6 +33,18 @@ def load_merged_manifest_dict(manifest_path: Path) -> Dict:
             with wrap_context('merging base & overlay layers'):
                 manifest_dict = merge_dicts(base_manifest_dict, manifest_dict)
                 manifest_dict['extends'] = None
+
+    with wrap_context('applying extra vars'):
+        for extra_key, extra_value in extra_vars.items():
+            assert extra_key, 'extra var key cannot be empty'
+            key_nodes: list[str] = extra_key.split('.')
+            last_name = key_nodes[-1]
+            target_node: Dict = manifest_dict
+            for key_node in key_nodes[:-1]:
+                target_node = target_node[key_node]
+            value_object = yaml.safe_load(extra_value)
+            target_node[last_name] = value_object
+
     return manifest_dict
 
 

--- a/racetrack_client/racetrack_client/manifest/merge.py
+++ b/racetrack_client/racetrack_client/manifest/merge.py
@@ -34,16 +34,17 @@ def load_merged_manifest_dict(manifest_path: Path, extra_vars: Dict[str, str]) -
                 manifest_dict = merge_dicts(base_manifest_dict, manifest_dict)
                 manifest_dict['extends'] = None
 
-    with wrap_context('applying extra vars'):
-        for extra_key, extra_value in extra_vars.items():
-            assert extra_key, 'extra var key cannot be empty'
-            key_nodes: list[str] = extra_key.split('.')
-            last_name = key_nodes[-1]
-            target_node: Dict = manifest_dict
-            for key_node in key_nodes[:-1]:
-                target_node = target_node[key_node]
-            value_object = yaml.safe_load(extra_value)
-            target_node[last_name] = value_object
+    if extra_vars:
+        with wrap_context('applying extra vars'):
+            for extra_key, extra_value in extra_vars.items():
+                assert extra_key, 'extra var key cannot be empty'
+                key_nodes: list[str] = extra_key.split('.')
+                last_name = key_nodes[-1]
+                target_node: Dict = manifest_dict
+                for key_node in key_nodes[:-1]:
+                    target_node = target_node[key_node]
+                value_object = yaml.safe_load(extra_value)
+                target_node[last_name] = value_object
 
     return manifest_dict
 

--- a/racetrack_client/racetrack_client/manifest/validate.py
+++ b/racetrack_client/racetrack_client/manifest/validate.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+from typing import Dict
 
 from jsonschema import validate
 
@@ -14,14 +15,18 @@ from racetrack_client.utils.semver import SemanticVersion
 logger = get_logger(__name__)
 
 
-def load_validated_manifest(path: str) -> Manifest:
+def load_validated_manifest(
+    path: str,
+    extra_vars: Dict[str, str] = None,
+) -> Manifest:
     """
     Load and validate manifest from a path. Raise exception in case of a defect.
-    :param path path to a Job manifest file or to a directory with it
+    :param path: path to a Job manifest file or to a directory with it
+    :param extra_vars: key-value pairs overriding manifest values
     :return loaded, valid Manifest
     """
     manifest_path = get_manifest_path(path)
-    manifest = load_merged_manifest(manifest_path)
+    manifest = load_merged_manifest(manifest_path, extra_vars or {})
 
     with wrap_context('validating manifest'):
         validate_manifest(manifest)
@@ -42,7 +47,10 @@ def validate_manifest(manifest: Manifest):
         SemanticVersion(manifest.version)
 
 
-def validate_and_show_manifest(path: str):
-    manifest = load_validated_manifest(path)
+def validate_and_show_manifest(
+    path: str,
+    extra_vars: Dict[str, str] = None,
+):
+    manifest = load_validated_manifest(path, extra_vars)
     logger.info(f'Manifest file "{path}" is valid')
     print(datamodel_to_yaml_str(manifest))

--- a/racetrack_client/tests/manifest/test_override.py
+++ b/racetrack_client/tests/manifest/test_override.py
@@ -1,0 +1,47 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+from racetrack_client.manifest.validate import load_validated_manifest
+
+
+def test_override_manifest_with_extra_vars():
+    path = tempfile.mkdtemp(prefix='job-test')
+    try:
+        (Path(path) / 'job.yaml').write_text("""
+name: golang-function
+owner_email: nobody@example.com
+lang: golang:latest
+replicas: 3
+git:
+  remote: https://github.com/TheRacetrack/racetrack
+  directory: sample/golang-function
+  branch: master
+""")
+        manifest_path = (Path(path) / 'job.yaml').as_posix()
+
+        manifest = load_validated_manifest(manifest_path, extra_vars={
+            'replicas': '7',
+            'owner_email': 'arnold@skynet.com',
+        })
+        assert manifest.name == 'golang-function'
+        assert manifest.replicas == 7
+        assert manifest.owner_email == 'arnold@skynet.com'
+        assert manifest.git.branch == 'master'
+
+        manifest = load_validated_manifest(manifest_path, extra_vars={
+            'git.branch': 'current',
+        })
+        assert manifest.git.branch == 'current'
+        assert manifest.git.directory == 'sample/golang-function'
+
+        manifest = load_validated_manifest(manifest_path, extra_vars={
+            'git': '{"remote": "https://github"}',
+        })
+        assert manifest.git.remote == 'https://github'
+        assert manifest.git.branch is None
+        assert manifest.git.directory == '.'
+        assert manifest.replicas == 3, 'other keys should remain untouched'
+
+    finally:
+        shutil.rmtree(path)

--- a/racetrack_client/tests/test_cli.py
+++ b/racetrack_client/tests/test_cli.py
@@ -1,0 +1,8 @@
+from racetrack_client.utils.shell import shell_output
+
+
+def test_cli_help():  # smoke test
+    output = shell_output('racetrack')
+    assert 'CLI client tool for managing workloads in Racetrack' in output
+    output = shell_output('racetrack deploy --help')
+    assert 'Send request deploying a Job to the Racetrack cluster' in output


### PR DESCRIPTION
### Added
- Manifest values can be overriden with key-value pairs coming from a command line.
  Racetrack client has `--extra-vars KEY=VALUE` parameter (or `-e` in short)
  that overwrites values found in YAML manifest.

  - `KEY` is the name of field and it can contain dots to refer to a nested field, for example `git.branch=master`.
  - `VALUE` can be any YAML or JSON object.

  Extra vars parameters can be used multiple times in one command.  
  Example: `racetrack deploy -e secret_runtime_env_file=.env.local -e git.branch=$(git rev-parse --abbrev-ref HEAD)`  
  It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.  
  Tip: Use `racetrack validate` command beforehand to make sure your final manifest is what you expected.