### PR TITLE
Add CLI command to get current auth token (X-Racetrack-Auth)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command `racetrack get auth-token` prints out current auth token.
   It can be used in CLI scripts: `curl -H "X-Racetrack-Auth: $(racetrack get auth-token)"`
   ([#357](https://github.com/TheRacetrack/racetrack/issues/357))
-- Command `racetrack login --username ADMIN` allows you to log in with your username and password and saves the auth token without having to visit the Dashboard page.
+- Command `racetrack login --username <username>` allows you to log in with your username and password
+  (entered into the standard input) and saves the auth token without having to visit the Dashboard page.
 
 ### Fixed
 - Manifest is validated after updating it on Dashboard.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using the installer script that runs it on the Docker Engine infrastructure.
   ([#308](https://github.com/TheRacetrack/racetrack/issues/308))
 
+- A new command `racetrack get auth-token` prints out current auth token.
+  It can be used in CLI scripts: `curl -H "X-Racetrack-Auth: $(racetrack get auth-token)"`
+  ([#357](https://github.com/TheRacetrack/racetrack/issues/357))
+
 ### Fixed
 - Manifest is validated after updating it on Dashboard.
   Changing primary keys (name or value) is forbidden.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,9 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using the installer script that runs it on the Docker Engine infrastructure.
   ([#308](https://github.com/TheRacetrack/racetrack/issues/308))
 
-- A new command `racetrack get auth-token` prints out current auth token.
+- Command `racetrack get auth-token` prints out current auth token.
   It can be used in CLI scripts: `curl -H "X-Racetrack-Auth: $(racetrack get auth-token)"`
   ([#357](https://github.com/TheRacetrack/racetrack/issues/357))
+- Command `racetrack login --username ADMIN` allows you to log in with your username and password and saves the auth token without having to visit the Dashboard page.
 
 ### Fixed
 - Manifest is validated after updating it on Dashboard.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -95,7 +95,7 @@ You can do it from CLI with an HTTP client as well:
 ```shell
 curl -X POST "http://127.0.0.1:7105/pub/job/adder/latest/api/v1/perform" \
   -H "Content-Type: application/json" \
-  -H "X-Racetrack-Auth: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZWVkIjoiY2UwODFiMDUtYTRhMC00MTRhLThmNmEtODRjMDIzMTkxNmE2Iiwic3ViamVjdCI6ImFkbWluIiwic3ViamVjdF90eXBlIjoidXNlciIsInNjb3BlcyI6bnVsbH0.xDUcEmR7USck5RId0nwDo_xtZZBD6pUvB2vL6i39DQI" \
+  -H "X-Racetrack-Auth: $(racetrack get auth-token)" \
   -d '{"a": 40, "b": 2}'
 # Expect: 42
 ```

--- a/racetrack_client/README.md
+++ b/racetrack_client/README.md
@@ -57,6 +57,8 @@ Log in to Racetrack with your user account (you can get your token from the Dash
 racetrack login T0k3n.g0es.H3r3
 ```
 
+Alternatively, command `racetrack login --username ADMIN` allows you to log in with your username and password and saves the auth token without having to visit the Dashboard page.
+
 In case you're going to use a private repository, provide your git credentials so the job can be built from your code:
 ```shell
 racetrack set credentials https://github.com/YourUser/YourRepository USERNAME TOKEN

--- a/racetrack_client/README.md
+++ b/racetrack_client/README.md
@@ -122,3 +122,7 @@ racetrack deploy -e secret_runtime_env_file=.env.local -e git.branch=$(git rev-p
 
 It makes CLI commands more script-friendly, so you can overwrite manifest without tracking changes in job.yaml file.  
 Tip: Use `racetrack validate` command beforehand to make sure your final manifest is what you expected.
+
+### Getting auth token
+Command `racetrack get auth-token` prints out current auth token.
+It can be used in CLI scripts: `curl -H "X-Racetrack-Auth: $(racetrack get auth-token)"`

--- a/racetrack_client/README.md
+++ b/racetrack_client/README.md
@@ -57,7 +57,8 @@ Log in to Racetrack with your user account (you can get your token from the Dash
 racetrack login T0k3n.g0es.H3r3
 ```
 
-Alternatively, command `racetrack login --username ADMIN` allows you to log in with your username and password and saves the auth token without having to visit the Dashboard page.
+Alternatively, command `racetrack login --username <username>` allows you to log in with your username and password
+(entered into the standard input) and saves the auth token without having to visit the Dashboard page.
 
 In case you're going to use a private repository, provide your git credentials so the job can be built from your code:
 ```shell

--- a/racetrack_client/racetrack_client/client_config/auth.py
+++ b/racetrack_client/racetrack_client/client_config/auth.py
@@ -1,15 +1,17 @@
 from typing import Optional
+from getpass import getpass
 
 from racetrack_client.client_config.alias import resolve_lifecycle_url
 from racetrack_client.client_config.client_config import ClientConfig
 from racetrack_client.client_config.io import load_client_config, save_client_config
 from racetrack_client.log.logs import get_logger
 from racetrack_client.utils.auth import is_auth_required, validate_user_auth, AuthError
+from racetrack_client.utils.request import Requests, parse_response_object
 
 logger = get_logger(__name__)
 
 
-def login_user_auth(lifecycle_url: str, user_auth: str):
+def login_user_auth(lifecycle_url: Optional[str], user_auth: str):
     client_config: ClientConfig = load_client_config()
     lifecycle_url = resolve_lifecycle_url(client_config, lifecycle_url)
     username = validate_user_auth(lifecycle_url, user_auth)
@@ -18,7 +20,7 @@ def login_user_auth(lifecycle_url: str, user_auth: str):
     logger.info(f'Logged as user {username} to Racetrack: {lifecycle_url}')
 
 
-def logout_user_auth(lifecycle_url: str):
+def logout_user_auth(lifecycle_url: Optional[str]):
     client_config: ClientConfig = load_client_config()
     lifecycle_url = resolve_lifecycle_url(client_config, lifecycle_url)
     set_user_auth(client_config, lifecycle_url, "")
@@ -55,3 +57,24 @@ def get_current_auth(remote: Optional[str]) -> str:
     client_config = load_client_config()
     lifecycle_url = resolve_lifecycle_url(client_config, remote)
     return get_user_auth(client_config, lifecycle_url)
+
+
+def login_with_username(remote: Optional[str], username: str):
+    client_config = load_client_config()
+    lifecycle_url = resolve_lifecycle_url(client_config, remote)
+    password = getpass(f'Enter your password for user {username}: ')
+    auth_token = authorize_username_password(lifecycle_url, username, password)
+    set_user_auth(client_config, lifecycle_url, auth_token)
+    save_client_config(client_config)
+    logger.info(f'Logged as user {username} to Racetrack: {lifecycle_url}')
+
+
+def authorize_username_password(lifecycle_url: str, username: str, password: str) -> str:
+    response = Requests.post(f'{lifecycle_url}/api/v1/users/login', json={
+        'username': username,
+        'password': password,
+    })
+    if response.status_code == 401:
+        raise AuthError('Incorrect username or password')
+    response_dict = parse_response_object(response, 'Lifecycle response error')
+    return response_dict['token']

--- a/racetrack_client/racetrack_client/client_config/auth.py
+++ b/racetrack_client/racetrack_client/client_config/auth.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from racetrack_client.client_config.alias import resolve_lifecycle_url
 from racetrack_client.client_config.client_config import ClientConfig
 from racetrack_client.client_config.io import load_client_config, save_client_config
@@ -47,3 +49,9 @@ def get_user_auth(client_config: ClientConfig, lifecycle_url: str) -> str:
         raise AuthError(f"missing auth token for {lifecycle_url}. You need to do: racetrack login <token> --remote {lifecycle_url}")
 
     return ''
+
+
+def get_current_auth(remote: Optional[str]) -> str:
+    client_config = load_client_config()
+    lifecycle_url = resolve_lifecycle_url(client_config, remote)
+    return get_user_auth(client_config, lifecycle_url)

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -10,7 +10,7 @@ from racetrack_client.client.deploy import BuildContextMethod, send_deploy_reque
 from racetrack_client.client.manage import JobTableColumn, move_job, delete_job, list_jobs, complete_job_name
 from racetrack_client.client.logs import show_runtime_logs, show_build_logs
 from racetrack_client.client.run import run_job_locally
-from racetrack_client.client_config.auth import login_user_auth, logout_user_auth, get_current_auth
+from racetrack_client.client_config.auth import login_user_auth, logout_user_auth, get_current_auth, login_with_username
 from racetrack_client.client_config.io import load_client_config
 from racetrack_client.client_config.update import set_credentials, set_current_remote, get_current_remote, set_config_url_alias
 from racetrack_client.plugin.bundler.bundle import bundle_plugin
@@ -149,11 +149,17 @@ def _version():
 
 @cli.command('login', no_args_is_help=True)
 def _login(
-    user_token: str = typer.Argument(..., show_default=False, help='Racetrack Auth Token from Racetrack\'s user profile'),
+    user_token: str = typer.Argument(default=None, show_default=False, help='Racetrack Auth Token from Racetrack\'s user profile'),
+    username: str = typer.Option(default=None, show_default=False, help="Username to authenticate"),
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
 ):
     """Save user's Racetrack Auth Token for Racetrack server"""
-    login_user_auth(remote, user_token)
+    if user_token:
+        login_user_auth(remote, user_token)
+    elif username:
+        login_with_username(remote, username)
+    else:
+        raise RuntimeError('Use either auth token or username')
 
 
 @cli.command('logout')

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -10,7 +10,7 @@ from racetrack_client.client.deploy import BuildContextMethod, send_deploy_reque
 from racetrack_client.client.manage import JobTableColumn, move_job, delete_job, list_jobs, complete_job_name
 from racetrack_client.client.logs import show_runtime_logs, show_build_logs
 from racetrack_client.client.run import run_job_locally
-from racetrack_client.client_config.auth import login_user_auth, logout_user_auth
+from racetrack_client.client_config.auth import login_user_auth, logout_user_auth, get_current_auth
 from racetrack_client.client_config.io import load_client_config
 from racetrack_client.client_config.update import set_credentials, set_current_remote, get_current_remote, set_config_url_alias
 from racetrack_client.plugin.bundler.bundle import bundle_plugin
@@ -165,7 +165,7 @@ def _logout(
 
 
 # racetrack set ...
-cli_set = typer.Typer(no_args_is_help=True, help='Set global options of the Racetrack client')
+cli_set = typer.Typer(no_args_is_help=True, help='Set local options of the Racetrack client')
 cli.add_typer(cli_set, name="set")
 
 
@@ -197,7 +197,7 @@ def _set_alias(
 
 
 # racetrack get ...
-cli_get = typer.Typer(no_args_is_help=True, help='Read global options of the Racetrack client')
+cli_get = typer.Typer(no_args_is_help=True, help='Read local options of the Racetrack client')
 cli.add_typer(cli_get, name="get")
 
 
@@ -212,6 +212,15 @@ def _get_config():
     """Show all racetrack config values"""
     client_config = load_client_config()
     print(datamodel_to_yaml_str(client_config))
+
+
+@cli_get.command('auth-token')
+def _get_auth_token(
+    remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
+):
+    """Show all racetrack config values"""
+    auth_token = get_current_auth(remote)
+    print(auth_token)
 
 
 # racetrack plugin ...

--- a/racetrack_client/racetrack_client/main.py
+++ b/racetrack_client/racetrack_client/main.py
@@ -224,7 +224,7 @@ def _get_config():
 def _get_auth_token(
     remote: str = typer.Option(default=None, show_default=False, help="Racetrack server's URL or alias name"),
 ):
-    """Show all racetrack config values"""
+    """Show currently logged in auth token"""
     auth_token = get_current_auth(remote)
     print(auth_token)
 


### PR DESCRIPTION
Command `racetrack get auth-token` prints out current auth token.
  It can be used in CLI scripts: `curl -H "X-Racetrack-Auth: $(racetrack get auth-token)"`

Command `racetrack login --username ADMIN` allows you to log in with your username and password and saves the auth token without having to visit the Dashboard page.