### PR TITLE
Make connection refused error retriable in async job calls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- "Connection refused" error is now retriable in async job calls (will be retried automatically).
+  ([#448](https://github.com/TheRacetrack/racetrack/issues/448))
 
 ## [2.29.2] - 2024-04-30
 ### Fixed

--- a/pub/async.go
+++ b/pub/async.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -215,7 +216,10 @@ func makeJobCall(
 		if errors.Is(err, io.EOF) {
 			return WrapError("connection broken to a target job (job may have died)", err), true
 		}
-		return WrapError("making request to a job", err), false
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			return WrapError("connection refused to a target job (job may have died)", err), true
+		}
+		return WrapError("making request to a job", err), true
 	}
 
 	// Transform redirect links to relative (without hostname).


### PR DESCRIPTION
### Changed
- "Connection refused" error is now retriable in async job calls (will be retried automatically).