### PR TITLE
Deployment getting stuck at finalizing the build phase

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,2 +1,1 @@
-httpx==0.24.0
 markdown==3.4.1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,6 +86,8 @@ services:
       DOCKER_HOST: tcp://docker-engine:2375
       CONFIG_FILE: /etc/racetrack/image-builder/config.yaml
       LIFECYCLE_AUTH_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZWVkIjoiZGVhNzYzMDAtN2JhYy00ODRjLTkyOTYtNWQxMGNkOTM3YTU4Iiwic3ViamVjdCI6ImltYWdlLWJ1aWxkZXIiLCJzdWJqZWN0X3R5cGUiOiJpbnRlcm5hbCIsInNjb3BlcyI6WyJmdWxsX2FjY2VzcyJdfQ.ND3wDeK58L5T1jIYcuArQ5O3M0Ez3_pCAEi5NXD_hLY
+    stdin_open: true
+    tty: true
 
   dashboard:
     container_name: dashboard
@@ -110,6 +112,8 @@ services:
       EXTERNAL_GRAFANA_URL: 'http://127.0.0.1:3100'
       AUTH_REQUIRED: 'true'
       SITE_NAME: ''
+    stdin_open: true
+    tty: true
 
   pub:
     container_name: pub

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Long deployments (over 20 minutes) no longer get stuck in the final stage.
+  ([#448](https://github.com/TheRacetrack/racetrack/issues/448))
 
 ## [2.29.2] - 2024-04-30
 ### Fixed

--- a/lifecycle/lifecycle/deployer/builder.py
+++ b/lifecycle/lifecycle/deployer/builder.py
@@ -2,6 +2,7 @@ import threading
 from typing import Optional, Dict
 
 import backoff
+import httpx
 
 from lifecycle.config import Config
 from lifecycle.infrastructure.infra_target import determine_infrastructure_name
@@ -10,7 +11,7 @@ from lifecycle.django.registry.database import db_access
 from lifecycle.job.deployment import create_deployment, save_deployment_build_logs, save_deployment_image_name, save_deployment_result, save_deployment_phase
 from racetrack_client.client_config.client_config import Credentials
 from racetrack_client.client.env import SecretVars
-from racetrack_client.utils.request import parse_response_object, Requests, RequestError
+from racetrack_client.utils.request import Requests, RequestError
 from racetrack_client.utils.datamodel import datamodel_to_dict
 from racetrack_client.utils.time import now
 from racetrack_client.log.context_error import wrap_context
@@ -20,6 +21,7 @@ from racetrack_client.manifest import Manifest
 from racetrack_commons.deploy.image import get_job_image
 from racetrack_commons.entities.dto import DeploymentDto, DeploymentStatus
 from racetrack_commons.plugin.engine import PluginEngine
+from racetrack_commons.api.server_sent_events import validate_streaming_response, extract_response_dict
 
 logger = get_logger(__name__)
 
@@ -55,18 +57,27 @@ def _send_image_build_request(
     """
     logger.info(f'building a job by image-builder, deployment ID: {deployment.id}')
     # see `image_builder.api._setup_api_endpoints`
-    r = Requests.post(
-        f'{config.image_builder_url}/api/v1/build',
-        json=_build_image_request_payload(manifest, git_credentials, secret_build_env, tag, build_context, deployment, build_flags),
-        timeout=3600,
-    )
+    payload = _build_image_request_payload(manifest, git_credentials, secret_build_env, tag, build_context, deployment, build_flags)
+    response_buffer = ''
+    with httpx.Client(timeout=3600) as client:
+        with client.stream('POST', f'{config.image_builder_url}/api/v1/build/sse', json=payload) as stream_response:
+            for line in stream_response.iter_lines():
+                if line.strip() == 'event: keepalive_heartbeat':
+                    logger.debug(f'building in progress: keepalive heartbeat for deployment {deployment.id}')
+                else:
+                    response_buffer += line + '\n'
+
     logger.debug(f'image-builder finished building a job, deployment ID: {deployment.id}')
-    response = parse_response_object(r, 'Image builder API error')
-    build_logs: str = response['logs']
+    validate_streaming_response(stream_response)
+    response = extract_response_dict(response_buffer)
+    error = response.get('error')
+    if error:
+        raise RuntimeError(f'image-builder error: {error}')
+    build_logs: str = response['result']['logs']
     image_name = get_job_image(config.docker_registry, config.docker_registry_namespace, manifest.name, tag)
     save_deployment_build_logs(deployment.id, build_logs)
     save_deployment_image_name(deployment.id, image_name)
-    error: str = response['error']
+    error: str = response['result']['error']
     if error:
         raise RuntimeError(error)
     logger.info(f'job image {image_name} has been built, deployment ID: {deployment.id}')

--- a/lifecycle/lifecycle/deployer/builder.py
+++ b/lifecycle/lifecycle/deployer/builder.py
@@ -58,6 +58,7 @@ def _send_image_build_request(
     r = Requests.post(
         f'{config.image_builder_url}/api/v1/build',
         json=_build_image_request_payload(manifest, git_credentials, secret_build_env, tag, build_context, deployment, build_flags),
+        timeout=3600,
     )
     logger.debug(f'image-builder finished building a job, deployment ID: {deployment.id}')
     response = parse_response_object(r, 'Image builder API error')

--- a/lifecycle/lifecycle/server/metrics.py
+++ b/lifecycle/lifecycle/server/metrics.py
@@ -10,7 +10,14 @@ from prometheus_client.registry import Collector
 
 from lifecycle.server.db_status import database_status
 
-metric_requested_job_deployments = Counter('requested_job_deployments', 'Number of requests to deploy job')
+metric_requested_job_deployments = Counter(
+    'requested_job_deployments',
+    'Number of started job deployments',
+)
+metric_done_job_deployments = Counter(
+    'done_job_deployments',
+    'Number of finished job deployments (processed or failed)',
+)
 metric_deployed_job = Counter('deployed_job', 'Number of Jobs deployed successfully')
 metric_metrics_scrapes = Counter('metrics_scrapes', 'Number of Prometheus metrics scrapes')
 

--- a/lifecycle/requirements.txt
+++ b/lifecycle/requirements.txt
@@ -10,3 +10,4 @@ werkzeug==2.3.8
 psutil==5.9.4
 falcon==3.1.3
 websockets==11.0.3
+httpx==0.27.0

--- a/lifecycle/requirements.txt
+++ b/lifecycle/requirements.txt
@@ -10,4 +10,3 @@ werkzeug==2.3.8
 psutil==5.9.4
 falcon==3.1.3
 websockets==11.0.3
-httpx==0.27.0

--- a/lifecycle/tests/sse/test_server_sent_events.py
+++ b/lifecycle/tests/sse/test_server_sent_events.py
@@ -15,7 +15,7 @@ def test_server_sent_events():
 
     def sse_generator():
         for num in range(3):
-            yield f'event: locationUpdate\ndata: {{"id": {num}}}\n\n'
+            yield f'data: {{"progress": {num}}}\n\n'
 
     @app.get("/sse")
     def sse_endpoint():
@@ -39,14 +39,11 @@ def test_server_sent_events():
 def _test_sse_client_get(port: int):
     response = httpx.get(f'http://127.0.0.1:{port}/sse')
     assert response.status_code == 200
-    assert response.text == '''event: locationUpdate
-data: {"id": 0}
+    assert response.text == '''data: {"progress": 0}
 
-event: locationUpdate
-data: {"id": 1}
+data: {"progress": 1}
 
-event: locationUpdate
-data: {"id": 2}
+data: {"progress": 2}
 
 '''
 
@@ -59,16 +56,15 @@ def _test_sse_client_stream(port: int):
                 lines.append(line)
 
     assert lines == [
-        'event: locationUpdate',
-        'data: {"id": 0}',
+        'data: {"progress": 0}',
         '',
-        'event: locationUpdate',
-        'data: {"id": 1}',
+        'data: {"progress": 1}',
         '',
-        'event: locationUpdate',
-        'data: {"id": 2}',
+        'data: {"progress": 2}',
         '',
     ]
+    stream_response.raise_for_status()
+    assert stream_response.status_code == 200
 
 
 @backoff.on_exception(backoff.fibo, httpx.RequestError, max_time=5, jitter=None)

--- a/lifecycle/tests/sse/test_server_sent_events.py
+++ b/lifecycle/tests/sse/test_server_sent_events.py
@@ -1,0 +1,77 @@
+import asyncio
+
+import backoff
+import httpx
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+from racetrack_client.log.logs import configure_logs
+from racetrack_commons.api.asgi.asgi_server import serve_asgi_in_background
+from racetrack_commons.socket import free_tcp_port
+
+
+def test_server_sent_events():
+    app = FastAPI()
+
+    def sse_generator():
+        for num in range(3):
+            yield f'event: locationUpdate\ndata: {{"id": {num}}}\n\n'
+
+    @app.get("/sse")
+    def sse_endpoint():
+        return StreamingResponse(sse_generator(), media_type="text/event-stream")
+
+    @app.get("/ready")
+    def ready_endpoint():
+        return
+
+    async def test_async():
+        configure_logs()
+        port = free_tcp_port()
+        with serve_asgi_in_background(app, port):
+            _wait_until_server_ready(port)
+            _test_sse_client_get(port)
+            _test_sse_client_stream(port)
+
+    asyncio.run(test_async())
+
+
+def _test_sse_client_get(port: int):
+    response = httpx.get(f'http://127.0.0.1:{port}/sse')
+    assert response.status_code == 200
+    assert response.text == '''event: locationUpdate
+data: {"id": 0}
+
+event: locationUpdate
+data: {"id": 1}
+
+event: locationUpdate
+data: {"id": 2}
+
+'''
+
+
+def _test_sse_client_stream(port: int):
+    lines = []
+    with httpx.Client(timeout=10) as client:
+        with client.stream('GET', f'http://127.0.0.1:{port}/sse') as stream_response:
+            for line in stream_response.iter_lines():
+                lines.append(line)
+
+    assert lines == [
+        'event: locationUpdate',
+        'data: {"id": 0}',
+        '',
+        'event: locationUpdate',
+        'data: {"id": 1}',
+        '',
+        'event: locationUpdate',
+        'data: {"id": 2}',
+        '',
+    ]
+
+
+@backoff.on_exception(backoff.fibo, httpx.RequestError, max_time=5, jitter=None)
+def _wait_until_server_ready(port: int):
+    response = httpx.get(f'http://127.0.0.1:{port}/ready')
+    assert response.status_code == 200

--- a/racetrack_commons/racetrack_commons/api/server_sent_events.py
+++ b/racetrack_commons/racetrack_commons/api/server_sent_events.py
@@ -1,13 +1,75 @@
 import json
-from typing import Dict
+from threading import Thread
+from typing import Dict, Callable
+import queue
 
-from httpx import Response
+import httpx
+from fastapi.responses import StreamingResponse
 
-RESULT_EVENT = 'event: result\n'
+from racetrack_client.log.logs import get_logger
+
+logger = get_logger(__name__)
+
+EVENT_RESULT = 'event: result\n'
+EVENT_HEARTBEAT = 'event: keepalive_heartbeat'
 DATA_MESSAGE = 'data: '
 
 
-def validate_streaming_response(response: Response):
+def stream_result_with_heartbeat(result_runner: Callable[[], Dict]):
+    """
+    Return result dict in SSE (Server-Sent Events) response, streaming heartbeat events to keep the connection alive
+    """
+    result_channel = queue.Queue(maxsize=0)
+
+    def _runner():
+        try:
+            result = result_runner()
+            result_channel.put(json.dumps({
+                'result': result,
+            }))
+        except BaseException as e:
+            result_channel.put(json.dumps({
+                'error': str(e),
+            }))
+
+    Thread(target=_runner, daemon=True).start()
+
+    def sse_generator():
+        while True:
+            try:
+                event_data: str = result_channel.get(block=True, timeout=60)
+                yield f'{EVENT_RESULT}data: {event_data}\n\n'
+                result_channel.task_done()
+                return
+            except queue.Empty:
+                yield f'{EVENT_HEARTBEAT}\n\n'
+
+    return StreamingResponse(sse_generator(), media_type="text/event-stream")
+
+
+def make_sse_request(
+    method: str,
+    url: str,
+    payload: Dict,
+):
+    response_buffer = ''
+    with httpx.Client(timeout=3600) as client:
+        with client.stream(method.upper(), url, json=payload) as stream_response:
+            for line in stream_response.iter_lines():
+                if line.strip() == 'event: keepalive_heartbeat':
+                    logger.debug(f'keepalive heartbeat for {method} {url}')
+                else:
+                    response_buffer += line + '\n'
+
+    validate_streaming_response(stream_response)
+    response = extract_response_dict(response_buffer)
+    error = response.get('error')
+    if error:
+        raise RuntimeError(f'Streaming Response error: {error}')
+    return response['result']
+
+
+def validate_streaming_response(response: httpx.Response):
     if response.is_success:
         return
     message = f'HTTP error "{response.status_code} {response.reason_phrase}" ' \
@@ -16,7 +78,7 @@ def validate_streaming_response(response: Response):
 
 
 def extract_response_dict(response_text: str) -> Dict:
-    prefix = RESULT_EVENT + DATA_MESSAGE
+    prefix = EVENT_RESULT + DATA_MESSAGE
     last_occurrence = response_text.find(prefix)
     if last_occurrence == -1:
         raise ValueError('could not find result event in the SSE response')

--- a/racetrack_commons/racetrack_commons/api/server_sent_events.py
+++ b/racetrack_commons/racetrack_commons/api/server_sent_events.py
@@ -1,0 +1,26 @@
+import json
+from typing import Dict
+
+from httpx import Response
+
+RESULT_EVENT = 'event: result\n'
+DATA_MESSAGE = 'data: '
+
+
+def validate_streaming_response(response: Response):
+    if response.is_success:
+        return
+    message = f'HTTP error "{response.status_code} {response.reason_phrase}" ' \
+              f'for url {response.request.method} {response.url}'
+    raise RuntimeError(message)
+
+
+def extract_response_dict(response_text: str) -> Dict:
+    prefix = RESULT_EVENT + DATA_MESSAGE
+    last_occurrence = response_text.find(prefix)
+    if last_occurrence == -1:
+        raise ValueError('could not find result event in the SSE response')
+
+    remainder = response_text[last_occurrence + len(prefix):]
+    json_dict = json.loads(remainder)
+    return json_dict

--- a/racetrack_commons/requirements.txt
+++ b/racetrack_commons/requirements.txt
@@ -8,3 +8,4 @@ protobuf==4.22.0  # needed by opentelemetry exporter
 python-multipart==0.0.9  # uploading files
 watchdog==2.3.1
 a2wsgi==1.10.4
+httpx==0.27.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,6 @@ coverage==7.2.1
 backoff==2.2.1
 httpretty==1.1.4
 Flask==2.2.5
-httpx==0.24.0
+httpx==0.27.0
 pytest-django==4.5.2
 anyio==3.6.2

--- a/utils/grafana/dashboards/lifecycle.json
+++ b/utils/grafana/dashboards/lifecycle.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 19,
+  "id": 5,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -52,6 +52,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -156,6 +157,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -272,6 +274,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -380,6 +383,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -485,6 +489,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -607,6 +612,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -626,6 +632,113 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "requested_job_deployments_total{job=~\"lifecycle.*\"} - done_job_deployments_total{job=~\"lifecycle.*\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Active deployments (Unfinished)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -666,7 +779,7 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 6,
+        "x": 12,
         "y": 8
       },
       "id": 5,
@@ -731,6 +844,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -771,7 +885,7 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 12,
+        "x": 18,
         "y": 8
       },
       "id": 10,
@@ -835,110 +949,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 8
-      },
-      "id": 8,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "sortBy": "Last *",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "8.3.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "lifecycle_tcp_connections_count",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "{{status}} {{instance}}",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "TCP connections",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -1041,6 +1052,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -1145,6 +1157,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -1228,6 +1241,111 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "lifecycle_tcp_connections_count",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{status}} {{instance}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "TCP connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Useful to determine pod restarts",
       "fieldConfig": {
         "defaults": {
@@ -1248,6 +1366,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -1288,8 +1407,8 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 18,
-        "y": 16
+        "x": 12,
+        "y": 24
       },
       "id": 9,
       "options": {
@@ -1375,7 +1494,7 @@
         "text": {},
         "textMode": "value_and_name"
       },
-      "pluginVersion": "9.3.6",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -1396,7 +1515,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1410,6 +1529,6 @@
   "timezone": "",
   "title": "Lifecycle",
   "uid": "VZLtJLFnz",
-  "version": 4,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
### Fixed

Long deployments (over 20 minutes) no longer get stuck in the final stage.

This is done by switching to Server-Sent Events, sending heartbeat messages to keep alive the connection during long requests.

Plus, couple of improvements in FastAPI ASGI app to clean up the request properly (and show logs) if a client disconnects.