### PR TITLE
Provide its own Dockerfile by a Job

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugins added to racetrack can now be downloaded via the CLI or the admin interface.
   ([#451](https://github.com/TheRacetrack/racetrack/issues/451))
 
+### Changed
+- The `job_types` method's format for plugins has been changed
+  to support providing Dockerfiles directly by the Jobs.
+  See [Developing plugins guide](./development/developing-plugins.md#job_types).
+  Previous format is still supported for backward compatibility.
+  ([#470](https://github.com/TheRacetrack/racetrack/issues/470))
+
 ## [2.29.3] - 2024-05-21
 ### Added
 - Racetrack is compatible with Python 3.12

--- a/docs/development/plugins-job-types.md
+++ b/docs/development/plugins-job-types.md
@@ -332,10 +332,10 @@ ENV DEPLOYED_BY_RACETRACK_VERSION "{{ deployed_by_racetrack_version }}"
 
 ```python
 class Plugin:
-    def job_types(self) -> dict[str, list[str]]:
+    def job_types(self) -> dict[str, dict]:
         """
         Job types provided by this plugin
-        :return dict of job type name (with version) -> list of images: dockerfile template path relative to a jobtype directory
+        :return dict of job type name (with version) mapped to a definition of images to build
         """
         return {
             f'golang:{self.plugin_manifest.version}': ['job-template.Dockerfile'],

--- a/docs/development/plugins-job-types.md
+++ b/docs/development/plugins-job-types.md
@@ -20,7 +20,6 @@ to extend Racetrack.
     template with the following variables, that gets built for each individual
     Job automatically by Racetrack.
 
-    - `base_image` - the name of the base docker image to use for building a Job
     - `env_vars` - dict with environment variables that should be assigned to the Job container
     - `manifest` - whole Job Manifest object (see [Job Manifest Schema](../manifest-schema.md))
     - `git_version` - version of the Job code taken from git repository

--- a/docs/development/plugins-job-types.md
+++ b/docs/development/plugins-job-types.md
@@ -35,7 +35,7 @@ to extend Racetrack.
 
     `plugin.py` describes the Plugin class - to be considered a job type, your
   `plugin.py` must at minimum implements the `job_types` method as described here in
-  [the documentation of all available hooks.](./developing-plugins.md#supported-hooks)
+  [the documentation of all available hooks.](./developing-plugins.md#job_types)
 
 6. Create a `.racetrackignore`
 
@@ -337,8 +337,17 @@ class Plugin:
         Job types provided by this plugin
         :return dict of job type name (with version) mapped to a definition of images to build
         """
+        plugin_version: str = getattr(self, 'plugin_manifest').version
         return {
-            f'golang:{self.plugin_manifest.version}': ['job-template.Dockerfile'],
+            f'golang:{plugin_version}': {
+                'images': [
+                    {
+                        'source': 'jobtype',
+                        'dockerfile_path': 'job-template.Dockerfile',
+                        'template': True,
+                    },
+                ],
+            },
         }
 ```
 </details>

--- a/docs/user/available-plugins.md
+++ b/docs/user/available-plugins.md
@@ -11,8 +11,14 @@ These are the known, public Racetrack plugins that are commonly available to be 
       racetrack plugin install github.com/TheRacetrack/plugin-python-job-type
       ```
 
-    - [Dockerfile-based Job Type](https://github.com/TheRacetrack/plugin-docker-proxy-job-type)
-      (any language or app wrapped in a Dockerfile like Drupal or Sphinx)
+    - [Dockerfile-based Job Type](https://github.com/TheRacetrack/plugin-dockerfile-job-type)
+      (any language or app wrapped in a Dockerfile)
+      ```
+      racetrack plugin install github.com/TheRacetrack/plugin-dockerfile-job-type
+      ```
+
+    - [Dockerfile Proxy Job Type](https://github.com/TheRacetrack/plugin-docker-proxy-job-type)
+      (app wrapped in a Dockerfile like Drupal or Sphinx with a proxy server that adheres to the Racetrack requirements)
       ```
       racetrack plugin install github.com/TheRacetrack/plugin-docker-proxy-job-type
       ```

--- a/docs/user/user-guide-1.md
+++ b/docs/user/user-guide-1.md
@@ -13,7 +13,7 @@ Racetrack allows you to use several languages and frameworks (provided by [insta
 * [Standard Python 3](https://github.com/TheRacetrack/plugin-python-job-type)
 * [Golang services](https://github.com/TheRacetrack/plugin-go-job-type)
 * [Rust](https://github.com/TheRacetrack/plugin-rust-job-type)
-* And for exotic edge cases, [any Dockerfile-wrapped code](https://github.com/TheRacetrack/plugin-docker-proxy-job-type)
+* And for exotic edge cases, [any Dockerfile-wrapped code](https://github.com/TheRacetrack/plugin-dockerfile-job-type)
 * [HUGO framework](https://github.com/TheRacetrack/plugin-hugo-job-type)
 * [Drupal](https://github.com/TheRacetrack/plugin-docker-proxy-job-type/tree/master/sample/drupal)
 * [Sphinx](https://github.com/TheRacetrack/plugin-docker-proxy-job-type/tree/master/sample/sphinx)

--- a/image_builder/image_builder/docker/builder.py
+++ b/image_builder/image_builder/docker/builder.py
@@ -18,7 +18,7 @@ from racetrack_client.manifest import Manifest
 from racetrack_client.utils.shell import shell, CommandError, shell_output
 from racetrack_client.utils.url import join_paths
 from racetrack_commons.deploy.image import get_job_image
-from racetrack_commons.deploy.job_type import JobType, load_job_type, JobTypeImageDef
+from racetrack_commons.deploy.job_type import JobType, load_job_type, JobTypeImageDef, ImageSourceLocation
 from racetrack_commons.plugin.engine import PluginEngine
 
 logger = get_logger(__name__)
@@ -106,7 +106,7 @@ def _build_job_image(
                 base_image = _build_base_image(config, job_type, image_def, image_index, deployment_id)
 
         src_dockerfile_path: Path = image_def.dockerfile_path
-        if image_def.source == 'job':  # User-module Dockerfile from a Job's workspace
+        if image_def.source == ImageSourceLocation.job:  # User-module Dockerfile from a Job's workspace
             src_dockerfile_path = job_workspace / image_def.dockerfile_path
             assert src_dockerfile_path.is_file(), f'User-module Dockerfile was not found in a job workspace: {image_def.dockerfile_path}'
         else:

--- a/lifecycle/lifecycle/deployer/provision.py
+++ b/lifecycle/lifecycle/deployer/provision.py
@@ -82,7 +82,7 @@ def provision_job(
             tag=tag,
             runtime_env_vars=runtime_env_vars,
             family=family_dto,
-            containers_num=job_type.containers_num,
+            containers_num=job_type.images_num,
             runtime_secret_vars=secret_runtime_env,
         )
 

--- a/racetrack_client/racetrack_client/manifest/manifest.py
+++ b/racetrack_client/racetrack_client/manifest/manifest.py
@@ -15,12 +15,6 @@ class GitManifest(BaseModel):
     directory: str = '.'
 
 
-class DockerManifest(BaseModel):
-    model_config = ConfigDict(extra='forbid')
-
-    dockerfile_path: Optional[str] = None
-
-
 class ResourcesManifest(BaseModel):
     model_config = ConfigDict(extra='forbid', arbitrary_types_allowed=True)
 
@@ -56,9 +50,6 @@ class Manifest(BaseModel):
     # relative path to base manifest file, which will be extended by this manifest
     extends: Optional[str] = None
 
-    # Docker-specific configuration
-    docker: Optional[DockerManifest] = None
-
     # type of deployed image: docker image, packer, AMI
     image_type: str = 'docker'
 
@@ -90,6 +81,7 @@ class Manifest(BaseModel):
     jobtype_extra: Optional[Dict[str, Any]] = None
     golang: Optional[Dict[str, Any]] = None  # Deprecated
     python: Optional[Dict[str, Any]] = None  # Deprecated
+    docker: Optional[Dict[str, Any]] = None  # Deprecated
     wrapper_properties: Optional[Dict[str, Any]] = None  # Deprecated
 
     # Back-end platform where to deploy the service

--- a/racetrack_commons/racetrack_commons/deploy/job_type.py
+++ b/racetrack_commons/racetrack_commons/deploy/job_type.py
@@ -150,6 +150,7 @@ def _parse_job_type_definition(
             job_type.images.append(image_def)
 
     elif isinstance(job_type_value, list):  # Deprecated: list of template paths
+        logger.warning('Using deprecated job type definition. Use dictionary format.')
         assert len(job_type_value), "job type data list shouldn't be empty"
         for item in job_type_value:
             assert isinstance(item, str), \
@@ -162,6 +163,7 @@ def _parse_job_type_definition(
             job_type.images.append(image_def)
 
     elif isinstance(job_type_value, str):  # Deprecated: one template path
+        logger.warning('Using deprecated job type definition. Use dictionary format.')
         image_def = JobTypeImageDef(
             source='jobtype',
             dockerfile_path=plugin_data.plugin_dir / job_type_value,
@@ -170,7 +172,7 @@ def _parse_job_type_definition(
         job_type.images.append(image_def)
 
     elif isinstance(job_type_value, tuple):  # Deprecated: tuple of (base image path, template path)
-        logger.warning('Using deprecated base images. Please use a single job template instead.')
+        logger.warning('Using deprecated base images. Please use a single job template with a dictionary format.')
         image_def = JobTypeImageDef(
             source='jobtype',
             base_image_path=Path(job_type_value[0]),

--- a/racetrack_commons/racetrack_commons/plugin/core.py
+++ b/racetrack_commons/racetrack_commons/plugin/core.py
@@ -36,10 +36,10 @@ class PluginCore(ABC):
         """Supplementary env vars dictionary added to runtime vars when deploying a Job"""
         return None
 
-    def job_types(self) -> dict[str, list[str]]:
+    def job_types(self) -> dict[str, dict]:
         """
         Job types provided by this plugin
-        :return dict of job type name (with version) -> list of images: dockerfile template path relative to a jobtype directory
+        :return dict of job type name (with version) mapped to a definition of images to build
         """
         return {}
 


### PR DESCRIPTION
### Changed
The `job_types` method's format for plugins has been changed
  to support providing Dockerfiles directly by the Jobs.
  See [Developing plugins guide](https://github.com/TheRacetrack/racetrack/blob/470-provide-dockerfile-from-a-job-repository/docs/development/developing-plugins.md#job_types).
  Previous format is still supported for backward compatibility.