### PR TITLE
Create ESC from the Dashboard

### DIFF
--- a/dashboard/dashboard-front/Makefile
+++ b/dashboard/dashboard-front/Makefile
@@ -6,7 +6,7 @@ setup:
 	nvm use v18.16 ;\
 	npm install
 
-run: 
+run:
 	. ./nvm-activate.sh ;\
 	npm run dev
 

--- a/dashboard/dashboard-front/src/components/NavDrawer.vue
+++ b/dashboard/dashboard-front/src/components/NavDrawer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { mdiGraphOutline, mdiTable, mdiAccountCircle, mdiTools, mdiLogout, mdiBookOpenVariant, mdiTextBoxOutline } from '@quasar/extras/mdi-v7'
+import { mdiGraphOutline, mdiTable, mdiAccountCircle, mdiTools, mdiLogout, mdiBookOpenVariant, mdiTextBoxOutline, mdiAccountNetwork } from '@quasar/extras/mdi-v7'
 import { outlinedMemory } from '@quasar/extras/material-icons-outlined'
 import { isAuthenticated, isAdmin } from '@/services/UserDataStore'
 
@@ -69,6 +69,16 @@ defineExpose({
           </q-item-section>
           <q-item-section>
             <q-item-label>Activity</q-item-label>
+          </q-item-section>
+        </q-item>
+
+        <q-item v-ripple clickable :to="{name: 'esc-list'}"
+          v-if="isAdmin">
+          <q-item-section avatar>
+            <q-icon :name="mdiAccountNetwork" />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label>External Consumers</q-item-label>
           </q-item-section>
         </q-item>
 

--- a/dashboard/dashboard-front/src/components/account/ProfileView.vue
+++ b/dashboard/dashboard-front/src/components/account/ProfileView.vue
@@ -60,7 +60,7 @@ function regenerateToken() {
                 </template>
             </q-field>
             
-            <q-field outlined label="Auth Token" stack-label class="q-mt-md">
+            <q-field outlined label="Auth Token (X-Racetrack-Auth)" stack-label class="q-mt-md">
                 <template v-slot:control>
                     <span class="x-monospace x-overflow-any">
                         {{ authToken }}

--- a/dashboard/dashboard-front/src/components/esc/CreateEscDialog.vue
+++ b/dashboard/dashboard-front/src/components/esc/CreateEscDialog.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, type Ref } from 'vue'
+import { progressService } from '@/services/ProgressService'
+import { apiClient } from '@/services/ApiClient'
+
+const dialogOpen = ref(false)
+const loading = ref(false)
+const escName: Ref<string> = ref('')
+
+function openDialog() {
+    dialogOpen.value = true
+}
+
+function createConsumer() {
+    progressService.runLoading({
+        task: apiClient.post(`/api/v1/escs`, {
+            'name': escName.value,
+        }),
+        loadingState: loading,
+        progressMsg: `Creating ESC...`,
+        successMsg: `ESC created.`,
+        errorMsg: `Failed to create ESC`,
+        onSuccess: () => {
+            dialogOpen.value = false
+            emit('escCreated', null)
+        },
+    })
+}
+
+const emit = defineEmits(['escCreated'])
+
+defineExpose({
+    openDialog,
+})
+</script>
+
+<template>
+    <q-dialog v-model="dialogOpen">
+        <q-card>
+            <q-card-section>
+                <div class="text-h6">Create a new External Service Consumer</div>
+            </q-card-section>
+            <q-card-section>
+                <div>
+                    <q-input
+                        outlined
+                        v-model="escName"
+                        label="Name"
+                        />
+                </div>
+                <div class="row q-pt-sm">
+                    <q-space />
+                    <q-btn flat color="white" text-color="black" label="Cancel" v-close-popup />
+                    <q-btn color="primary" push label="Create" icon="add"
+                        @click="createConsumer" :loading="loading" />
+                </div>
+            </q-card-section>
+        </q-card>
+    </q-dialog>
+</template>

--- a/dashboard/dashboard-front/src/components/esc/ExternalConsumerDetails.vue
+++ b/dashboard/dashboard-front/src/components/esc/ExternalConsumerDetails.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { toastService } from '@/services/ToastService'
+import { apiClient } from '@/services/ApiClient'
+import {type EscDetails} from '@/utils/api-schema'
+import {copyToClipboard} from "quasar";
+
+const route = useRoute()
+const escId = route.params.escId
+const escDetails = ref<EscDetails | null>(null)
+
+function fetchConsumerData() {
+    apiClient.get<EscDetails>(`/api/v1/escs/${escId}/auth_data`)
+        .then(response => {
+            escDetails.value = response.data
+        }).catch(err => {
+            toastService.showErrorDetails(`Failed to fetch ESC details`, err)
+        })
+}
+
+function copyAuthToken() {
+    copyToClipboard(escDetails.value?.token || '')
+        .then(() => {
+            toastService.success(`Auth Token copied to clipboard.`)
+        }).catch((error) => {
+            toastService.error(`Failed to copy to clipboard.`)
+        })
+}
+
+onMounted(() => {
+    fetchConsumerData()
+})
+</script>
+
+<template>
+    <q-card>
+        <q-card-section>
+            <div class="text-h6">External Service Consumer Details</div>
+        </q-card-section>
+
+        <q-card-section>
+            <q-field outlined label="ID" stack-label>
+                <template v-slot:control>
+                    {{ escDetails?.id }}
+                </template>
+            </q-field>
+
+            <q-field outlined label="Name" stack-label>
+                <template v-slot:control>
+                    <div>{{ escDetails?.name }}</div>
+                </template>
+            </q-field>
+
+            <q-field outlined label="Auth Token (X-Racetrack-Auth)" stack-label>
+                <template v-slot:control>
+                    <span class="x-monospace x-overflow-any">
+                        {{ escDetails?.token }}
+                    </span>
+                </template>
+                <template v-slot:append>
+                    <q-btn round dense flat icon="content_copy" @click="copyAuthToken" />
+                </template>
+            </q-field>
+        </q-card-section>
+    </q-card>
+</template>

--- a/dashboard/dashboard-front/src/components/esc/ExternalConsumers.vue
+++ b/dashboard/dashboard-front/src/components/esc/ExternalConsumers.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import {onMounted, ref} from 'vue'
+import {onMounted, type Ref, ref} from 'vue'
 import {toastService} from '@/services/ToastService'
 import {apiClient} from '@/services/ApiClient'
 import {type EscDto} from '@/utils/api-schema'
 import {mdiAccountNetwork} from "@quasar/extras/mdi-v7";
+import CreateEscDialog from "@/components/esc/CreateEscDialog.vue";
 
 const consumersData = ref<EscDto[]>([])
 const loading = ref(true)
+const createEscDialogRef: Ref<typeof CreateEscDialog | null> = ref(null)
 
 function fetchConsumersData() {
     loading.value = true
@@ -20,12 +22,21 @@ function fetchConsumersData() {
         })
 }
 
+function createNewEsc() {
+    createEscDialogRef.value?.openDialog()
+}
+
+function onEscCreated() {
+    fetchConsumersData()
+}
+
 onMounted(() => {
     fetchConsumersData()
 })
 </script>
 
 <template>
+    <CreateEscDialog ref="createEscDialogRef" @escCreated="onEscCreated" />
     <q-card>
         <q-card-section class="q-pb-none">
             <span class="text-h6">
@@ -35,7 +46,7 @@ onMounted(() => {
 
         <q-card-section class="q-pb-none">
             <div class="full-width row wrap justify-end">
-                <q-btn color="primary" push label="Create a new ESC" icon="add" :to="{name: 'deploy-job'}" />
+                <q-btn color="primary" push label="Create a new ESC" icon="add" @click="createNewEsc()" />
             </div>
         </q-card-section>
 

--- a/dashboard/dashboard-front/src/components/esc/ExternalConsumers.vue
+++ b/dashboard/dashboard-front/src/components/esc/ExternalConsumers.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import {onMounted, ref} from 'vue'
+import {toastService} from '@/services/ToastService'
+import {apiClient} from '@/services/ApiClient'
+import {type EscDto} from '@/utils/api-schema'
+import {mdiAccountNetwork} from "@quasar/extras/mdi-v7";
+
+const consumersData = ref<EscDto[]>([])
+const loading = ref(true)
+
+function fetchConsumersData() {
+    loading.value = true
+    apiClient.get<EscDto[]>(`/api/v1/escs`)
+        .then(response => {
+            consumersData.value = response.data
+        }).catch(err => {
+            toastService.showErrorDetails(`Failed to fetch external service consumers`, err)
+        }).finally(() => {
+            loading.value = false
+        })
+}
+
+onMounted(() => {
+    fetchConsumersData()
+})
+</script>
+
+<template>
+    <q-card>
+        <q-card-section class="q-pb-none">
+            <span class="text-h6">
+                External Service Consumers
+            </span>
+        </q-card-section>
+
+        <q-card-section class="q-pb-none">
+            <div class="full-width row wrap justify-end">
+                <q-btn color="primary" push label="Create a new ESC" icon="add" :to="{name: 'deploy-job'}" />
+            </div>
+        </q-card-section>
+
+        <q-card-section>
+            <q-list bordered separator class="rounded-borders">
+
+                <q-item v-if="!consumersData.length" class="text-grey-6">(empty)</q-item>
+
+                <q-item clickable v-ripple
+                        v-for="item in consumersData"
+                        :to="{name: 'esc-details', params: {escId: item.id}}">
+
+                    <q-item-section avatar>
+                        <q-icon :name="mdiAccountNetwork" />
+                    </q-item-section>
+
+                    <q-item-section>
+                        <q-item-label>{{item.name}}</q-item-label>
+                        <q-item-label caption>{{item.id}}</q-item-label>
+                    </q-item-section>
+                </q-item>
+            </q-list>
+            <q-inner-loading :showing="loading">
+                <q-spinner-gears size="50px" color="primary" />
+            </q-inner-loading>
+        </q-card-section>
+
+    </q-card>
+</template>

--- a/dashboard/dashboard-front/src/router/index.ts
+++ b/dashboard/dashboard-front/src/router/index.ts
@@ -21,6 +21,8 @@ import ProfileView from '@/components/account/ProfileView.vue'
 import AdministrationView from '@/components/admin/AdministrationView.vue'
 import PluginConfigView from '@/components/admin/PluginConfigView.vue'
 import PageNotFound from '@/components/PageNotFound.vue'
+import ExternalConsumers from "@/components/esc/ExternalConsumers.vue";
+import ExternalConsumerDetails from "@/components/esc/ExternalConsumerDetails.vue";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -52,6 +54,18 @@ const router = createRouter({
       path: '/deployments/:deploymentId',
       name: 'deployment-details',
       component: DeploymentDetails,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/esc',
+      name: 'esc-list',
+      component: ExternalConsumers,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/esc/:escId',
+      name: 'esc-details',
+      component: ExternalConsumerDetails,
       meta: { requiresAuth: true },
     },
     {

--- a/dashboard/dashboard-front/src/utils/api-schema.ts
+++ b/dashboard/dashboard-front/src/utils/api-schema.ts
@@ -39,3 +39,14 @@ export interface DeploymentDto {
     job_name: string
     job_version: string
 }
+
+export interface EscDto {
+    name: string
+    id?: string
+}
+
+export interface EscDetails {
+    id: string
+    name: string
+    token: string
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- A new tab "External Consumers" has been added to the Dashboard.
+  It allows to browse, read auth token and create a new ESC.
+  The tab is only available for administrator users.
+  ([#484](https://github.com/TheRacetrack/racetrack/issues/484))
+
 ### Changed
 - Reconciliation loop is now turned off by default. It can be enabled in configuration, if needed.
   Instead, reconciliation can be triggered manually through the Dashboard, at Administration tab.

--- a/lifecycle/lifecycle/endpoints/esc.py
+++ b/lifecycle/lifecycle/endpoints/esc.py
@@ -2,11 +2,11 @@ from typing import Optional
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field
 
+from lifecycle.auth.subject import get_auth_subject_by_esc
 from racetrack_client.utils.datamodel import parse_dict_datamodel
-from racetrack_commons.auth.scope import AuthScope
 from racetrack_commons.entities.dto import EscDto
-from lifecycle.job.esc import list_escs, create_esc
-from lifecycle.auth.check import check_auth
+from lifecycle.job.esc import list_escs, create_esc, read_esc_model
+from lifecycle.auth.check import check_staff_user
 
 
 def setup_esc_endpoints(api: APIRouter):
@@ -23,14 +23,26 @@ def setup_esc_endpoints(api: APIRouter):
         )
 
     @api.get('/escs')
-    def _get_all_escs(request: Request):
+    def _get_all_escs(request: Request) -> list[EscDto]:
         """Get list of all ESC"""
-        check_auth(request, scope=AuthScope.CALL_ADMIN_API)
+        check_staff_user(request)
         return list(list_escs())
 
     @api.post('/escs')
-    def _create_esc(payload: EscPayloadModel, request: Request):
+    def _create_esc(payload: EscPayloadModel, request: Request) -> EscDto:
         """Create new ESC"""
-        check_auth(request, scope=AuthScope.CALL_ADMIN_API)
+        check_staff_user(request)
         esc = parse_dict_datamodel(payload.model_dump(), EscDto)
         return create_esc(esc)
+
+    @api.get('/escs/{esc_id}/auth_data')
+    def _get_esc_auth_data(esc_id: str, request: Request):
+        """Get ESC's all details with auth token"""
+        check_staff_user(request)
+        esc_model = read_esc_model(esc_id)
+        auth_subject = get_auth_subject_by_esc(esc_model)
+        return {
+            'id': esc_id,
+            'name': esc_model.name,
+            'token': auth_subject.token,
+        }

--- a/lifecycle/lifecycle/job/esc.py
+++ b/lifecycle/lifecycle/job/esc.py
@@ -27,6 +27,7 @@ def read_esc_model(esc_id: str) -> models.Esc:
 
 @db_access
 def create_esc(esc_dto: EscDto) -> EscDto:
+    assert esc_dto.name, 'ESC name can not be empty'
     esc_model = models.Esc()
     esc_model.name = esc_dto.name
 


### PR DESCRIPTION
### Added
- A new tab "External Consumers" has been added to the Dashboard.
  It allows to browse, read auth token and create a new ESC.
  The tab is only available for administrator users.

![image](https://github.com/user-attachments/assets/0eb27df6-e90e-40d6-9c05-84dcf0c0dd66)
