### PR TITLE
multiple kubernetes infrastructure target plugins

### DIFF
--- a/racetrack_client/racetrack_client/log/errors.py
+++ b/racetrack_client/racetrack_client/log/errors.py
@@ -8,3 +8,6 @@ class AlreadyExists(RuntimeError):
 
 class ValidationError(RuntimeError):
     pass
+
+class IncompatibleOptions(RuntimeError):
+    pass

--- a/racetrack_client/racetrack_client/log/errors.py
+++ b/racetrack_client/racetrack_client/log/errors.py
@@ -8,6 +8,3 @@ class AlreadyExists(RuntimeError):
 
 class ValidationError(RuntimeError):
     pass
-
-class IncompatibleOptions(RuntimeError):
-    pass

--- a/racetrack_commons/racetrack_commons/plugin/engine.py
+++ b/racetrack_commons/racetrack_commons/plugin/engine.py
@@ -12,7 +12,7 @@ from watchdog.events import FileSystemEventHandler
 from racetrack_commons.plugin.loader import load_plugin_from_zip, load_plugins_from_dir, EXTRACTED_PLUGINS_DIR
 from racetrack_commons.plugin.plugin_data import PluginData
 from racetrack_client.log.context_error import wrap_context, ContextError
-from racetrack_client.log.errors import EntityNotFound, IncompatibleOptions
+from racetrack_client.log.errors import EntityNotFound, AlreadyExists
 from racetrack_client.log.exception import log_exception
 from racetrack_client.log.logs import get_logger
 from racetrack_client.plugin.plugin_manifest import PluginManifest
@@ -219,9 +219,7 @@ class PluginEngine:
                 for plugin in self.find_plugins(plugin_name):
                     if plugin.plugin_manifest.category == 'infrastructure':
                         if not replace:
-                            raise IncompatibleOptions('Infrastructure plugin with same name already exists. There can not be multiple infrastructure plugins with the same name. Use --replace if you want to replace the existing infrastructure pluging. ')
-                        self._delete_older_plugins(plugin_name)
-
+                            raise AlreadyExists('Infrastructure plugin with same name already exists. There can not be multiple infrastructure plugins with the same name. Use --replace if you want to replace the existing infrastructure pluging. ')
             if replace:
                 self._delete_older_plugins(plugin_name)
             else:

--- a/racetrack_commons/racetrack_commons/plugin/engine.py
+++ b/racetrack_commons/racetrack_commons/plugin/engine.py
@@ -12,7 +12,7 @@ from watchdog.events import FileSystemEventHandler
 from racetrack_commons.plugin.loader import load_plugin_from_zip, load_plugins_from_dir, EXTRACTED_PLUGINS_DIR
 from racetrack_commons.plugin.plugin_data import PluginData
 from racetrack_client.log.context_error import wrap_context, ContextError
-from racetrack_client.log.errors import EntityNotFound
+from racetrack_client.log.errors import EntityNotFound, IncompatibleOptions
 from racetrack_client.log.exception import log_exception
 from racetrack_client.log.logs import get_logger
 from racetrack_client.plugin.plugin_manifest import PluginManifest
@@ -218,7 +218,8 @@ class PluginEngine:
             if plugin_data.plugin_manifest.category == 'infrastructure':
                 for plugin in self.find_plugins(plugin_name):
                     if plugin.plugin_manifest.category == 'infrastructure':
-                        logger.warning(f'Infrastructure plugin with the same name already exists: {plugin_name}. {plugin_name} will replace the existing one.')
+                        if not replace:
+                            raise IncompatibleOptions('Infrastructure plugin with same name already exists. There can not be multiple infrastructure plugins with the same name. Use --replace if you want to replace the existing infrastructure pluging. ')
                         self._delete_older_plugins(plugin_name)
 
             if replace:

--- a/racetrack_commons/racetrack_commons/plugin/engine.py
+++ b/racetrack_commons/racetrack_commons/plugin/engine.py
@@ -209,10 +209,17 @@ class PluginEngine:
                 except PermissionError:
                     logger.warning(f'Can\'t change permissions of file {tmp_zip}')
             tmp_zip.write_bytes(file_bytes)
-            
+
             plugin_data = load_plugin_from_zip(tmp_zip)
             plugin_name = plugin_data.plugin_manifest.name
             plugin_version = plugin_data.plugin_manifest.version
+
+            # We only want one infrastructure plugin with the same name
+            if plugin_data.plugin_manifest.category == 'infrastructure':
+                for plugin in self.find_plugins(plugin_name):
+                    if plugin.plugin_manifest.category == 'infrastructure':
+                        logger.warning(f'Infrastructure plugin with the same name already exists: {plugin_name}. {plugin_name} will replace the existing one.')
+                        self._delete_older_plugins(plugin_name)
 
             if replace:
                 self._delete_older_plugins(plugin_name)
@@ -240,7 +247,7 @@ class PluginEngine:
         logger.info(f'Plugin config ({name} {version}) has been overwritten: {plugin_data.config_path}')
         self._record_last_change()
         self._load_plugins()
-        
+
     def delete_plugin_by_version(self, name: str, version: str):
         try:
             plugin_data = self.find_plugin(name, version)
@@ -310,7 +317,7 @@ class PluginEngine:
         if not txt:
             return 0
         return int(txt.strip())
-    
+
     def _record_last_change(self):
         self.last_change_timestamp = datetime_to_timestamp(now())
         change_file = self.plugins_path / LAST_CHANGE_FILE


### PR DESCRIPTION
This overwrites other infrastructure plugins with the same name.

Now we need to inform the racetrack_client and the webinterface when this happens.