### PR TITLE
Cache PUB internal calls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Internal calls of Pub service are cached for a short configurable time of 1-10 minutes.
+  This improves performance and robustness in case of Lifecycle, network or database issues.
+  ([#213](https://github.com/TheRacetrack/racetrack/issues/213))
 
 ## [2.33.0] - 2024-10-01
 ### Changed

--- a/pub/async.go
+++ b/pub/async.go
@@ -60,10 +60,11 @@ func handleTaskStartRequest(
 		return http.StatusBadRequest, errors.New("couldn't extract job version")
 	}
 
-	job, _, callerName, statusCode, err := getAuthorizedJobDetails(c, services, requestId, jobName, jobVersion, jobPath)
+	jobCall, callerName, statusCode, err := getAuthorizedJobDetails(c, services, requestId, jobName, jobVersion, jobPath)
 	if err != nil {
 		return statusCode, err
 	}
+	job := jobCall.Job
 
 	metricAsyncJobCallsStarted.WithLabelValues(job.Name, job.Version).Inc()
 	urlPath := JoinURL("/pub/job/", job.Name, job.Version, jobPath)

--- a/pub/async_test.go
+++ b/pub/async_test.go
@@ -201,7 +201,9 @@ func activateMockResponsesWithDelay(wgResultRequested *sync.WaitGroup) {
 func setupReplicaServer(addr string, cfg *Config, taskStore *AsyncTaskStore) *http.Server {
 	gin.SetMode(gin.ReleaseMode) // Hide Debug Routings
 	router := gin.New()
-	SetupEndpoints(router, cfg, "/pub", taskStore)
+	services := InitServices(cfg)
+	services.asyncTaskStore = taskStore
+	SetupEndpoints(router, cfg, "/pub", services)
 
 	server := &http.Server{
 		Addr:    addr,

--- a/pub/config.go
+++ b/pub/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ReplicaDiscoveryHostname string `env:"REPLICA_DISCOVERY_HOSTNAME" envDefault:""`
 	AsyncMaxAttempts         int    `env:"ASYNC_MAX_ATTEMPTS" envDefault:"2"`         // Maximum number of attempts to make a job call (1 is no retry)
 	AsyncTaskRetryInterval   int    `env:"ASYNC_TASK_RETRY_INTERVAL" envDefault:"10"` // Interval in seconds to wait before retrying a crashed job call
+	LifecycleCacheTTL        int    `env:"LIFECYCLE_CACHE_TTL" envDefault:"300"`      // Time-to-live in seconds to keep cached Lifecycle responses
 }
 
 func LoadConfig() (*Config, error) {

--- a/pub/config.go
+++ b/pub/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	AsyncMaxAttempts         int    `env:"ASYNC_MAX_ATTEMPTS" envDefault:"2"`         // Maximum number of attempts to make a job call (1 is no retry)
 	AsyncTaskRetryInterval   int    `env:"ASYNC_TASK_RETRY_INTERVAL" envDefault:"10"` // Interval in seconds to wait before retrying a crashed job call
 	LifecycleCacheTTLMin     int    `env:"LIFECYCLE_CACHE_TTL_MIN" envDefault:"60"`   // Time-to-live in seconds to keep cached Lifecycle responses
-	LifecycleCacheTTLMax     int    `env:"LIFECYCLE_CACHE_TTL_MAX" envDefault:"300"`  // Time-to-live in seconds to keep cached Lifecycle responses in case of Lifecycle/Database outage
+	LifecycleCacheTTLMax     int    `env:"LIFECYCLE_CACHE_TTL_MAX" envDefault:"600"`  // Time-to-live in seconds to keep cached Lifecycle responses in case of Lifecycle/Database outage
 }
 
 func LoadConfig() (*Config, error) {

--- a/pub/config.go
+++ b/pub/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	ReplicaDiscoveryHostname string `env:"REPLICA_DISCOVERY_HOSTNAME" envDefault:""`
 	AsyncMaxAttempts         int    `env:"ASYNC_MAX_ATTEMPTS" envDefault:"2"`         // Maximum number of attempts to make a job call (1 is no retry)
 	AsyncTaskRetryInterval   int    `env:"ASYNC_TASK_RETRY_INTERVAL" envDefault:"10"` // Interval in seconds to wait before retrying a crashed job call
-	LifecycleCacheTTL        int    `env:"LIFECYCLE_CACHE_TTL" envDefault:"300"`      // Time-to-live in seconds to keep cached Lifecycle responses
+	LifecycleCacheTTL        int    `env:"LIFECYCLE_CACHE_TTL" envDefault:"60"`       // Time-to-live in seconds to keep cached Lifecycle responses
 }
 
 func LoadConfig() (*Config, error) {

--- a/pub/config.go
+++ b/pub/config.go
@@ -23,7 +23,8 @@ type Config struct {
 	ReplicaDiscoveryHostname string `env:"REPLICA_DISCOVERY_HOSTNAME" envDefault:""`
 	AsyncMaxAttempts         int    `env:"ASYNC_MAX_ATTEMPTS" envDefault:"2"`         // Maximum number of attempts to make a job call (1 is no retry)
 	AsyncTaskRetryInterval   int    `env:"ASYNC_TASK_RETRY_INTERVAL" envDefault:"10"` // Interval in seconds to wait before retrying a crashed job call
-	LifecycleCacheTTL        int    `env:"LIFECYCLE_CACHE_TTL" envDefault:"60"`       // Time-to-live in seconds to keep cached Lifecycle responses
+	LifecycleCacheTTLMin     int    `env:"LIFECYCLE_CACHE_TTL_MIN" envDefault:"60"`   // Time-to-live in seconds to keep cached Lifecycle responses
+	LifecycleCacheTTLMax     int    `env:"LIFECYCLE_CACHE_TTL_MAX" envDefault:"300"`  // Time-to-live in seconds to keep cached Lifecycle responses in case of Lifecycle/Database outage
 }
 
 func LoadConfig() (*Config, error) {

--- a/pub/lifecycle_cache.go
+++ b/pub/lifecycle_cache.go
@@ -60,8 +60,12 @@ func (c *LifecycleCache) Get(jobName, jobVersion, endpoint, authToken string) (*
 	}
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
-	task, ok := c.cachedResponses[request]
-	return task, ok
+	response, ok := c.cachedResponses[request]
+	if response.createdAt.Add(c.timeToLive).Before(time.Now()) {
+		delete(c.cachedResponses, request)
+		return nil, false
+	}
+	return response, ok
 }
 
 func (c *LifecycleCache) cleanUpRoutine() {

--- a/pub/lifecycle_cache.go
+++ b/pub/lifecycle_cache.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/sha256"
+	"sync"
+	"time"
+)
+
+type LifecycleCache struct {
+	cachedResponses map[AuthorizeCallRequest]*AuthorizeCallResponse
+	rwMutex         sync.RWMutex
+	timeToLive      time.Duration
+	cleanUpPeriod   time.Duration
+}
+
+type AuthorizeCallRequest struct {
+	JobName       string
+	JobVersion    string
+	Endpoint      string
+	AuthTokenHash string
+}
+
+type AuthorizeCallResponse struct {
+	AuthData  *JobCallAuthData
+	createdAt time.Time
+}
+
+func NewLifecycleCache(cfg *Config) *LifecycleCache {
+	cache := &LifecycleCache{
+		cachedResponses: make(map[AuthorizeCallRequest]*AuthorizeCallResponse),
+		timeToLive:      time.Duration(cfg.LifecycleCacheTTL) * time.Second,
+		cleanUpPeriod:   1 * time.Minute,
+	}
+	go cache.cleanUpRoutine()
+	return cache
+}
+
+func (c *LifecycleCache) Put(jobName, jobVersion, endpoint, authToken string, authData *JobCallAuthData) {
+	request := AuthorizeCallRequest{
+		JobName:       jobName,
+		JobVersion:    jobVersion,
+		Endpoint:      endpoint,
+		AuthTokenHash: calculateHash(authToken),
+	}
+	response := &AuthorizeCallResponse{
+		AuthData:  authData,
+		createdAt: time.Now(),
+	}
+	c.rwMutex.Lock()
+	c.cachedResponses[request] = response
+	c.rwMutex.Unlock()
+}
+
+func (c *LifecycleCache) Get(jobName, jobVersion, endpoint, authToken string) (*AuthorizeCallResponse, bool) {
+	request := AuthorizeCallRequest{
+		JobName:       jobName,
+		JobVersion:    jobVersion,
+		Endpoint:      endpoint,
+		AuthTokenHash: calculateHash(authToken),
+	}
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+	task, ok := c.cachedResponses[request]
+	return task, ok
+}
+
+func (c *LifecycleCache) cleanUpRoutine() {
+	for {
+		time.Sleep(c.cleanUpPeriod)
+		c.rwMutex.Lock()
+		for request, response := range c.cachedResponses {
+			if response.createdAt.Add(c.timeToLive).Before(time.Now()) {
+				delete(c.cachedResponses, request)
+			}
+		}
+		c.rwMutex.Unlock()
+	}
+}
+
+func calculateHash(input string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(input))
+	return string(hasher.Sum(nil))
+}

--- a/pub/lifecycle_cache.go
+++ b/pub/lifecycle_cache.go
@@ -61,7 +61,7 @@ func (c *LifecycleCache) Get(jobName, jobVersion, endpoint, authToken string) (*
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 	response, ok := c.cachedResponses[request]
-	if response.createdAt.Add(c.timeToLive).Before(time.Now()) {
+	if response != nil && response.createdAt.Add(c.timeToLive).Before(time.Now()) {
 		delete(c.cachedResponses, request)
 		return nil, false
 	}

--- a/pub/lifecycle_cache.go
+++ b/pub/lifecycle_cache.go
@@ -66,6 +66,7 @@ func (c *LifecycleCache) RetrieveResponse(jobName, jobVersion, endpoint, authTok
 	if response != nil && response.createdAt.Add(c.timeToLiveMin).Before(time.Now()) {
 		return nil, false
 	}
+	metricLifecycleCacheRetrievedResponses.Inc()
 	return response, ok
 }
 
@@ -83,6 +84,7 @@ func (c *LifecycleCache) RecoverFailedResponse(jobName, jobVersion, endpoint, au
 		delete(c.cachedResponses, request)
 		return nil, false
 	}
+	metricLifecycleCacheRecoveredFailedResponses.Inc()
 	return response, ok
 }
 

--- a/pub/metrics.go
+++ b/pub/metrics.go
@@ -111,4 +111,13 @@ var (
 		Name: "pub_async_retried_missing_task",
 		Help: "Total number of retried async tasks due to a missing task",
 	})
+
+	metricLifecycleCacheRetrievedResponses = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pub_lifecycle_cache_retrieved_responses",
+		Help: "Total number of responses retrieved from the Lifecycle cache",
+	})
+	metricLifecycleCacheRecoveredFailedResponses = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pub_lifecycle_cache_recovered_failed_responses",
+		Help: "Total number of responses recovered from the Lifecycle cache due to a failure",
+	})
 )

--- a/pub/proxy.go
+++ b/pub/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,6 +28,9 @@ func proxyEndpoint(c *gin.Context, services *Services, jobPath string) {
 	logger := log.New(log.Ctx{
 		"requestId": requestId,
 	})
+	if strings.HasPrefix(jobPath, "//") {
+		jobPath = jobPath[1:]
+	}
 
 	logger.Info("Incoming Proxy request", log.Ctx{"method": c.Request.Method, "path": c.Request.URL.Path})
 	statusCode, err := handleProxyRequest(c, services, logger, requestId, jobPath, startTime)
@@ -251,10 +255,11 @@ func getAuthorizedJobDetails(
 	if ok && cachedResponse != nil {
 		jobCall := cachedResponse.AuthData
 		log.Debug("Reusing cached Lifecycle response", log.Ctx{
-			"jobName":    jobName,
-			"jobVersion": jobVersion,
-			"jobPath":    jobPath,
-			"requestId":  requestId,
+			"jobName":        jobName,
+			"jobVersion":     jobVersion,
+			"jobPath":        jobPath,
+			"requestId":      requestId,
+			"cacheEntryTime": cachedResponse.createdAt,
 		})
 		return jobCall, *jobCall.Caller, http.StatusOK, nil
 	}

--- a/pub/remote_forward.go
+++ b/pub/remote_forward.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -16,6 +17,9 @@ func remoteForwardEndpoint(c *gin.Context, cfg *Config, jobPath string) {
 	logger := log.New(log.Ctx{
 		"requestId": requestId,
 	})
+	if strings.HasPrefix(jobPath, "//") {
+		jobPath = jobPath[1:]
+	}
 
 	logger.Info("Incoming forwarding request from main Pub", log.Ctx{"method": c.Request.Method, "path": c.Request.URL.Path})
 	statusCode, err := handleRemoteForwardRequest(c, cfg, logger, requestId, jobPath, startTime)

--- a/pub/services.go
+++ b/pub/services.go
@@ -1,0 +1,25 @@
+package main
+
+type Services struct {
+	config         *Config
+	asyncTaskStore *AsyncTaskStore
+	lifecycleCache *LifecycleCache
+}
+
+func InitServices(cfg *Config) *Services {
+	replicaDiscovery := NewReplicaDiscovery(cfg)
+	taskStorage := NewLifecycleTaskStorage(cfg.LifecycleUrl, cfg.LifecycleToken)
+	asyncTaskStore := NewAsyncTaskStore(replicaDiscovery, taskStorage)
+
+	lifecycleCache := NewLifecycleCache(cfg)
+
+	return &Services{
+		config:         cfg,
+		asyncTaskStore: asyncTaskStore,
+		lifecycleCache: lifecycleCache,
+	}
+}
+
+func (s *Services) Shutdown() {
+	s.asyncTaskStore.CancelOngoingRequests()
+}


### PR DESCRIPTION
### Added
- Internal calls of Pub service are cached for a short configurable time of 1-10 minutes.
  This improves performance and robustness in case of Lifecycle, network or database issues.