### PR TITLE
Do not use uv in make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endef
 -include .local.env
 
 setup:
-	uv venv venv &&\
+	python3 -m venv venv &&\
 	. venv/bin/activate &&\
 	pip install --upgrade pip setuptools &&\
 	pip install -r requirements-test.txt -r requirements-dev.txt &&\


### PR DESCRIPTION
Make setup creates venv with python3 venv.
To setup using uv make venv can be used instead.

resolves #571  