### PR TITLE
Rewrite path when proxying "latest" job requests

### DIFF
--- a/pub/proxy.go
+++ b/pub/proxy.go
@@ -18,6 +18,8 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+const versionLatest string = "latest"
+
 var defaultJobProxyTransport http.RoundTripper = defaultHttpTransport()
 
 func proxyEndpoint(c *gin.Context, services *Services, jobPath string) {
@@ -94,13 +96,13 @@ func handleProxyRequest(
 	metricJobProxyRequests.WithLabelValues(job.Name, job.Version).Inc()
 
 	if !cfg.RemoteGatewayMode && jobCall.RemoteGatewayUrl != nil {
-		return handleMasterProxyRequest(c, cfg, logger, requestId, jobPath, jobCall, job, callerName, startTime)
+		return handleMasterProxyRequest(c, cfg, logger, requestId, jobPath, jobCall, job, callerName, startTime, jobVersion == versionLatest)
 	}
 
 	urlPath := JoinURL("/pub/job/", job.Name, job.Version, jobPath)
 	targetUrl := TargetURL(cfg, job, urlPath)
 
-	ServeReverseProxy(targetUrl, c, job, cfg, logger, requestId, callerName, startTime)
+	ServeReverseProxy(targetUrl, c, job, cfg, logger, requestId, callerName, startTime, jobVersion == versionLatest)
 	return http.StatusOK, nil
 }
 
@@ -126,6 +128,7 @@ func ServeReverseProxy(
 	requestId string,
 	callerName string,
 	startTime time.Time,
+	isCallingLatest bool,
 ) {
 
 	director := func(req *http.Request) {
@@ -150,6 +153,13 @@ func ServeReverseProxy(
 			if err == nil {
 				redirectUrl.Host = ""
 				redirectUrl.Scheme = ""
+
+				if isCallingLatest {
+					redirectUrl.Path = strings.Replace(redirectUrl.Path, "/"+job.Version, "/"+versionLatest, 1)
+					// clear RawPath to make sure there is no mismatch after changing Path
+					redirectUrl.RawPath = ""
+				}
+				
 				res.Header.Set("Location", redirectUrl.String())
 			}
 		}

--- a/pub/proxy_test.go
+++ b/pub/proxy_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/inconshreveable/log15"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServeReverseProxy(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/pub/job/adder/0.0.1/api/v1/perform", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "hello from "+r.URL.Path)
+	})
+
+	mux.HandleFunc("/pub/job/adder/0.0.1/redirect-me", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+r.Host+"/pub/job/adder/0.0.1/api/v1/perform", http.StatusFound)
+	})
+
+	job := httptest.NewServer(mux)
+	defer job.Close()
+
+	jobURL, err := url.Parse(job.URL)
+	assert.NoError(t, err)
+
+	cfg := &Config{
+		ForwardToProtocol:    "http",
+		RequestTracingHeader: "X-Request-Tracing-Id",
+		CallerNameHeader:     "X-Caller-Name",
+	}
+	jobDetails := &JobDetails{
+		Name:         "adder",
+		Version:      "0.0.1",
+		InternalName: jobURL.Host,
+	}
+
+	router := gin.New()
+	router.Any("/pub/job/:job/:version/*path", func(c *gin.Context) {
+		isCallingLatest := c.Param("version") == "latest"
+		target := url.URL{
+			Scheme: jobURL.Scheme,
+			Host:   jobURL.Host,
+			Path:   "/pub/job/" + jobDetails.Name + "/" + jobDetails.Version + c.Param("path"),
+		}
+		ServeReverseProxy(target, c, jobDetails, cfg, log.New(), "trace-123", "bob", time.Now(), isCallingLatest)
+	})
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	res, err := http.Get(server.URL + "/pub/job/adder/latest/api/v1/perform")
+	assert.NoError(t, err)
+	body, err := io.ReadAll(res.Body)
+	assert.NoError(t, err)
+	res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "hello from /pub/job/adder/0.0.1/api/v1/perform", string(body))
+	assert.Equal(t, "trace-123", res.Header.Get("X-Request-Tracing-Id"))
+	
+
+	// stop redirect to check where it redirects to
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	res, err = client.Get(server.URL + "/pub/job/adder/latest/redirect-me")
+	assert.NoError(t, err)
+	res.Body.Close()
+
+	assert.Equal(t, http.StatusFound, res.StatusCode)
+	assert.Equal(t, "/pub/job/adder/latest/api/v1/perform", res.Header.Get("Location"))
+	
+}

--- a/pub/remote_forward.go
+++ b/pub/remote_forward.go
@@ -94,6 +94,6 @@ func handleRemoteForwardRequest(
 		"targetUrl":       targetUrl.String(),
 	})
 
-	ServeReverseProxy(targetUrl, c, job, cfg, logger, requestId, callerName, startTime)
+	ServeReverseProxy(targetUrl, c, job, cfg, logger, requestId, callerName, startTime, jobVersion == versionLatest)
 	return http.StatusOK, nil
 }

--- a/pub/remote_gateway.go
+++ b/pub/remote_gateway.go
@@ -78,6 +78,7 @@ func handleMasterProxyRequest(
 	job *JobDetails,
 	callerName string,
 	startTime time.Time,
+	isCallingLatest bool,
 ) (int, error) {
 	gatewayUrlTxt := *jobCall.RemoteGatewayUrl
 	gatewayUrl, err := url.Parse(gatewayUrlTxt)
@@ -109,7 +110,7 @@ func handleMasterProxyRequest(
 		"jobInternalName":      job.InternalName,
 	})
 
-	ServeReverseProxy(*targetUrl, c, job, cfg, logger, requestId, callerName, startTime)
+	ServeReverseProxy(*targetUrl, c, job, cfg, logger, requestId, callerName, startTime, isCallingLatest)
 	return http.StatusOK, nil
 }
 

--- a/tests/e2e/test_proxy.py
+++ b/tests/e2e/test_proxy.py
@@ -1,0 +1,66 @@
+import os
+from urllib import request as urllib_request
+from urllib.error import HTTPError
+
+from racetrack_client.log.logs import configure_logs
+from racetrack_client.utils.auth import RT_AUTH_HEADER
+from racetrack_commons.entities.esc_client import EscRegistryClient
+
+from e2e.utils import (
+    DOCKER_PLUGIN_VERSION,
+    INTERNAL_AUTH_TOKEN,
+    K8S_PLUGIN_VERSION,
+    PYTHON_PLUGIN_VERSION,
+    _configure_env,
+    _create_esc,
+    _delete_workload,
+    _deploy,
+    _install_plugin,
+    _wait_for_components,
+)
+
+
+class _NoRedirectHandler(urllib_request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def test_latest_version_redirect():
+    configure_logs()
+    environment = _configure_env()
+    _wait_for_components()
+
+    _install_plugin(f'github.com/TheRacetrack/plugin-python-job-type=={PYTHON_PLUGIN_VERSION}')
+    if environment == 'docker':
+        _install_plugin(f'github.com/TheRacetrack/plugin-docker-infrastructure=={DOCKER_PLUGIN_VERSION}', replace=True)
+    elif environment == 'kind':
+        _install_plugin(f'github.com/TheRacetrack/plugin-kubernetes-infrastructure=={K8S_PLUGIN_VERSION}', replace=True)
+
+    esc = _create_esc()
+    assert esc is not None, 'failed to create ESC'
+    _delete_workload('adder')
+    _deploy('sample/python-class')
+
+    erc = EscRegistryClient(auth_token=INTERNAL_AUTH_TOKEN)
+    erc.esc_allow_job(esc_id=esc.id, job_name='adder')
+    esc_token = erc.get_esc_auth_token(esc.id)
+
+    pub_url = os.environ['PUB_URL']
+    url = f'{pub_url}/job/adder/latest'
+
+    opener = urllib_request.build_opener(_NoRedirectHandler())
+    req = urllib_request.Request(url, method='GET')
+    req.add_header(RT_AUTH_HEADER, esc_token)
+
+    try:
+        response = opener.open(req)
+        status = response.status
+        location = response.headers.get('Location')
+    except HTTPError as e:
+        status = e.code
+        location = e.headers.get('Location')
+
+    assert 300 <= status < 400, f'expected redirect response, got {status}'
+    assert location is not None, 'missing Location header'
+    assert '/pub/job/adder/latest' in location, f'unexpected location, got: {location!r}'
+    


### PR DESCRIPTION
Jobs can, and often will issue redirect responses. When uses sends request to the "latest" job version, but then url is redirected by job, user would end up on a page with actual version number. This is inconsistent with usual behavior where user is always kept with urls containing "latest" as the version.

This change rewrites any redirect requests issued by jobs to keep "latest" version in them.

Resolves #598 