### PR TITLE
Support for arm64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@
 
 # docker tag of images
 TAG ?= 2.36.0
-DOCKER_REGISTRY ?= ghcr.io
-DOCKER_REGISTRY_NAMESPACE ?= theracetrack/racetrack
-GHCR_PREFIX = ghcr.io/theracetrack/racetrack
+GHCR_REGISTRY ?= ghcr.io
+GHCR_NAMESPACE ?= theracetrack/racetrack
+GHCR_PREFIX = $(GHCR_REGISTRY)/$(GHCR_NAMESPACE)
+DOCKER_REGISTRY ?= $(GHCR_REGISTRY)
+DOCKER_REGISTRY_NAMESPACE ?= $(GHCR_NAMESPACE)
 DOCKER_GID=$(shell (getent group docker || echo 'docker:x:0') | cut -d: -f3 )
 
 docker-compose = COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_SCAN_SUGGEST=false DOCKER_GID=${DOCKER_GID} \
@@ -261,27 +263,37 @@ docker-build-debug:
 docker-build-stress:
 	$(docker-compose) -f tests/stress/docker-compose.stress.yaml build
 
-docker-push-private: docker-build
-	docker login ${DOCKER_REGISTRY}
-	docker buildx build -t ${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/lifecycle:${TAG} -f lifecycle/private.Dockerfile lifecycle
-	docker push ${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/lifecycle:${TAG}
-	$(call docker_tag_and_push,${GHCR_PREFIX}/image-builder:latest,${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/image-builder:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/dashboard:latest,${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/dashboard:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/pub:latest,${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/pub:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/pgbouncer:latest,${DOCKER_REGISTRY}/${DOCKER_REGISTRY_NAMESPACE}/pgbouncer:${TAG})
+# this configuration is for publishing builds only
+# local deployment via docker compose or kind will use machine architecture
+# platforms by default is set only to linux/amd64
+PLATFORMS ?= linux/amd64
+BUILDX_BUILDER ?= racetrack-multiarch
+GIT_VERSION = $(shell git describe --long --tags --dirty --always)
 
-docker-push-public: docker-build
-	docker login ghcr.io
-	docker push ${GHCR_PREFIX}/lifecycle:latest
-	docker push ${GHCR_PREFIX}/image-builder:latest
-	docker push ${GHCR_PREFIX}/dashboard:latest
-	docker push ${GHCR_PREFIX}/pub:latest
-	docker push ${GHCR_PREFIX}/pgbouncer:latest
-	$(call docker_tag_and_push,${GHCR_PREFIX}/lifecycle:latest,${GHCR_PREFIX}/lifecycle:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/image-builder:latest,${GHCR_PREFIX}/image-builder:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/dashboard:latest,${GHCR_PREFIX}/dashboard:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/pub:latest,${GHCR_PREFIX}/pub:${TAG})
-	$(call docker_tag_and_push,${GHCR_PREFIX}/pgbouncer:latest,${GHCR_PREFIX}/pgbouncer:${TAG})
+buildx-setup:
+	docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1 || \
+		docker buildx create --name $(BUILDX_BUILDER) --driver docker-container
+	docker buildx inspect --builder $(BUILDX_BUILDER) --bootstrap
+
+# do not invoke manually, use docker-push-private or docker-push-public instead
+# EXTRA_TAGS is a comma-separated list of additional tags (e.g. "latest")
+# LIFECYCLE_TARGET=private for private build of lifecycle containing certificates
+docker-push: buildx-setup
+	docker login $(PUSH_REGISTRY)
+	PUSH_REGISTRY=$(PUSH_REGISTRY) PUSH_NAMESPACE=$(PUSH_NAMESPACE) \
+	TAG=$(TAG) PLATFORMS=$(PLATFORMS) GIT_VERSION=$(GIT_VERSION) \
+	EXTRA_TAGS=$(EXTRA_TAGS) LIFECYCLE_TARGET=$(LIFECYCLE_TARGET) \
+		docker buildx bake -f docker-bake.hcl --builder $(BUILDX_BUILDER) --push
+
+docker-push-private: PUSH_REGISTRY = $(DOCKER_REGISTRY)
+docker-push-private: PUSH_NAMESPACE = $(DOCKER_REGISTRY_NAMESPACE)
+docker-push-private: LIFECYCLE_TARGET = private
+docker-push-private: docker-push
+
+docker-push-public: PUSH_REGISTRY = $(GHCR_REGISTRY)
+docker-push-public: PUSH_NAMESPACE = $(GHCR_NAMESPACE)
+docker-push-public: EXTRA_TAGS = latest
+docker-push-public: docker-push
 
 local-registry-push: docker-build
 	$(call docker_tag_and_push,${GHCR_PREFIX}/lifecycle:latest,127.0.0.1:5000/racetrack/lifecycle:latest)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,64 @@
+variable "PUSH_REGISTRY"    {}
+variable "PUSH_NAMESPACE"   {}
+variable "TAG"              { default = "latest" }
+variable "PLATFORMS"        { default = "linux/amd64" }
+variable "EXTRA_TAGS"       { default = "" }
+variable "GIT_VERSION"      { default = "" }
+variable "LIFECYCLE_TARGET" { default = "" }
+
+function "image_tags" {
+  params = [name]
+  result = concat(
+    ["${PUSH_REGISTRY}/${PUSH_NAMESPACE}/${name}:${TAG}"],
+    [for t in split(",", EXTRA_TAGS) :
+       "${PUSH_REGISTRY}/${PUSH_NAMESPACE}/${name}:${t}" if t != ""],
+  )
+}
+
+target "_base" {
+  platforms = split(",", PLATFORMS)
+  args = {
+    GIT_VERSION = GIT_VERSION
+    DOCKER_TAG  = TAG
+  }
+}
+
+group "default" {
+  targets = ["lifecycle", "image-builder", "dashboard", "pub", "pgbouncer"]
+}
+
+target "lifecycle" {
+  inherits   = ["_base"]
+  context    = "."
+  dockerfile = "lifecycle/Dockerfile"
+  target     = LIFECYCLE_TARGET != "" ? LIFECYCLE_TARGET : null
+  tags       = image_tags("lifecycle")
+}
+
+target "image-builder" {
+  inherits   = ["_base"]
+  context    = "."
+  dockerfile = "image_builder/Dockerfile"
+  tags       = image_tags("image-builder")
+}
+
+target "dashboard" {
+  inherits   = ["_base"]
+  context    = "."
+  dockerfile = "dashboard/Dockerfile"
+  tags       = image_tags("dashboard")
+}
+
+target "pub" {
+  inherits   = ["_base"]
+  context    = "pub"
+  dockerfile = "Dockerfile"
+  tags       = image_tags("pub")
+}
+
+target "pgbouncer" {
+  platforms  = split(",", PLATFORMS)
+  context    = "postgres/pgbouncer"
+  dockerfile = "Dockerfile"
+  tags       = image_tags("pgbouncer")
+}

--- a/docs/deployment/local-kubernetes-setup.md
+++ b/docs/deployment/local-kubernetes-setup.md
@@ -214,42 +214,5 @@ If it doesn't work, diagnostic commands:
 ## FAQ
 ### I want to build on an ARM system (such as M1 Mac)
 
-Disclaimer: we don't officially support or test for those architectures, but after
-little tweaking you should be still able to run on them. 
-
-To build on an ARM system, you need to add the docker arm64 repositories to the 
-image_builder and lifecycle Dockerfiles so apt-get can find the docker tools for amd64. 
-You can do so by applying the following diff (save it in repo root and `git apply arm64_enable.diff`):
-<details>
-  <summary>File `arm64_enable.diff`</summary>
-    
-    ```diff
-    diff --git a/image_builder/Dockerfile b/image_builder/Dockerfile
-    index 4dddd57..110564e 100644
-    --- a/image_builder/Dockerfile
-    +++ b/image_builder/Dockerfile
-    @@ -11,6 +11,9 @@ RUN apt-get update -y && apt-get install -y \
-     RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
-         echo \
-       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-    +  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
-    +    echo \
-    +  "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
-         apt-get update -y && apt-get install -y docker-ce-cli
-
-    diff --git a/lifecycle/Dockerfile b/lifecycle/Dockerfile
-    index 2063911..a2e196d 100644
-    --- a/lifecycle/Dockerfile
-    +++ b/lifecycle/Dockerfile
-    @@ -11,6 +11,9 @@ RUN apt-get update -y && apt-get install -y \
-     RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
-         echo \
-       "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-    +  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
-    +    echo \
-    +  "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-       $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
-         apt-get update -y && apt-get install -y docker-ce-cli
-    ```
-</details>
+Local deployment, both Docker and Kind based will build images matching your machine architecture.
+Note however, that by default public images and those created by version-release-private are linux/arm64 only.

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -68,3 +68,8 @@ will bump the dev part if MR is set in file, otherwise it bumps just the semver 
    ```sh
    make version-release-private version-release-public
    ```
+
+## Multi-platform builds
+
+By default version-release-private and version-release-public are linux/amd64 only.
+That can be controlled by PLATFORMS variable that can be set to another platform or a list of platforms.

--- a/image_builder/Dockerfile
+++ b/image_builder/Dockerfile
@@ -1,4 +1,20 @@
+FROM python:3.11-slim-bullseye AS builder
+
+RUN apt-get update -y && apt-get install -y gcc python3-dev &&\
+    rm -rf /var/lib/apt/lists/*
+
+COPY racetrack_client/setup.py racetrack_client/requirements.txt racetrack_client/README.md /src/racetrack_client/
+COPY racetrack_commons/setup.py racetrack_commons/requirements.txt /src/racetrack_commons/
+COPY image_builder/setup.py image_builder/requirements.txt /src/image_builder/
+RUN pip wheel --wheel-dir /wheels \
+  -r /src/racetrack_client/requirements.txt \
+  -r /src/racetrack_commons/requirements.txt \
+  -r /src/image_builder/requirements.txt
+
+
 FROM python:3.11-slim-bullseye AS base
+
+ARG TARGETARCH
 
 # install Docker CLI
 RUN apt-get update -y && apt-get install -y \
@@ -12,7 +28,7 @@ RUN apt-get update -y && apt-get install -y \
     vim
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
     echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
     apt-get update -y && apt-get install -y docker-ce-cli &&\
     rm -rf /var/lib/apt/lists/*
@@ -31,9 +47,12 @@ COPY .dockerignore /src/
 COPY racetrack_client/setup.py racetrack_client/requirements.txt racetrack_client/README.md /src/racetrack_client/
 COPY racetrack_commons/setup.py racetrack_commons/requirements.txt /src/racetrack_commons/
 COPY image_builder/setup.py image_builder/requirements.txt /src/image_builder/
-RUN pip install -r /src/racetrack_client/requirements.txt \
+COPY --from=builder /wheels /wheels
+RUN pip install --no-index --find-links=/wheels \
+  -r /src/racetrack_client/requirements.txt \
   -r /src/racetrack_commons/requirements.txt \
-  -r /src/image_builder/requirements.txt
+  -r /src/image_builder/requirements.txt &&\
+  rm -rf /wheels
 
 COPY racetrack_client/racetrack_client/. /src/racetrack_client/racetrack_client/
 COPY racetrack_commons/racetrack_commons/. /src/racetrack_commons/racetrack_commons/

--- a/lifecycle/Dockerfile
+++ b/lifecycle/Dockerfile
@@ -1,4 +1,20 @@
+FROM python:3.12-slim-bullseye AS builder
+
+RUN apt-get update -y && apt-get install -y gcc python3-dev &&\
+    rm -rf /var/lib/apt/lists/*
+
+COPY racetrack_client/setup.py racetrack_client/requirements.txt racetrack_client/README.md /src/racetrack_client/
+COPY racetrack_commons/setup.py racetrack_commons/requirements.txt /src/racetrack_commons/
+COPY lifecycle/setup.py lifecycle/requirements.txt /src/lifecycle/
+RUN pip wheel --wheel-dir /wheels \
+  -r /src/racetrack_client/requirements.txt \
+  -r /src/racetrack_commons/requirements.txt \
+  -r /src/lifecycle/requirements.txt
+
+
 FROM python:3.12-slim-bullseye AS base
+
+ARG TARGETARCH
 
 # install Docker CLI
 RUN apt-get update -y && apt-get install -y \
@@ -13,7 +29,7 @@ RUN apt-get update -y && apt-get install -y \
     vim
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg &&\
     echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null &&\
     apt-get update -y && apt-get install -y docker-ce-cli &&\
     rm -rf /var/lib/apt/lists/*
@@ -25,7 +41,7 @@ RUN useradd -u 100000 -m racetrack &&\
     /home/racetrack/.local/lib/python3.12/site-packages
 
 # install kubectl
-RUN curl -L "https://dl.k8s.io/release/v1.26.2/bin/linux/amd64/kubectl" \
+RUN curl -L "https://dl.k8s.io/release/v1.26.2/bin/linux/${TARGETARCH}/kubectl" \
     -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
@@ -34,9 +50,12 @@ WORKDIR /src/lifecycle
 COPY racetrack_client/setup.py racetrack_client/requirements.txt racetrack_client/README.md /src/racetrack_client/
 COPY racetrack_commons/setup.py racetrack_commons/requirements.txt /src/racetrack_commons/
 COPY lifecycle/setup.py lifecycle/requirements.txt postgres/wait-for-postgres.sh postgres/wait-for-migration.sh /src/lifecycle/
-RUN pip install -r /src/racetrack_client/requirements.txt \
+COPY --from=builder /wheels /wheels
+RUN pip install --no-index --find-links=/wheels \
+  -r /src/racetrack_client/requirements.txt \
   -r /src/racetrack_commons/requirements.txt \
-  -r /src/lifecycle/requirements.txt
+  -r /src/lifecycle/requirements.txt &&\
+  rm -rf /wheels
 
 COPY racetrack_client/racetrack_client/. /src/racetrack_client/racetrack_client/
 COPY racetrack_commons/racetrack_commons/. /src/racetrack_commons/racetrack_commons/
@@ -61,6 +80,11 @@ FROM base AS debug
 
 RUN pip install debugpy
 CMD ["python", "-u", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "lifecycle", "serve"]
+
+FROM base AS private
+COPY lifecycle/ca-certificates/* /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+CMD ["python", "-u", "-m", "lifecycle", "serve"]
 
 FROM base
 

--- a/lifecycle/private.Dockerfile
+++ b/lifecycle/private.Dockerfile
@@ -1,4 +1,0 @@
-# Bake custom CA certificates into the image intended for private use
-FROM ghcr.io/theracetrack/racetrack/lifecycle:latest
-COPY ca-certificates/* /usr/local/share/ca-certificates/
-RUN update-ca-certificates


### PR DESCRIPTION
- updated lifecycle and image builder to use TARGETARCH to use correct binaries
- lifecycle and image builder now have build stage with additional dependencies
- moved "private" lifecycle image definition from separate docker file to a stage in main docker file - that allows us to not depend on public lifecycle image to be used as base
- switched to building images via buildx to allow more configuration, most importantly possibility of multi-arch builds
-  definitions of builds for pushing are now in "bake" hcl file

resolves #614 